### PR TITLE
New Type convertion for integer, double, and decimal attributes

### DIFF
--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateRestEntities.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateRestEntities.fs
@@ -39,6 +39,7 @@ let getOrgVariables (list: XrmAttribute list) =
       | SpecialType.OptionSet       -> TsType.SpecificGeneric("SDK.OptionSet", [v.varType])
       | SpecialType.Money           -> TsType.Custom "SDK.Money"
       | SpecialType.EntityReference -> TsType.Custom "SDK.EntityReference"
+      | SpecialType.Decimal         -> TsType.String
       | _ -> v.varType
       |> fun ty -> TsType.Union [ty; TsType.Null]
     Variable.Create(v.schemaName, vType, optional = true))

--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateWebEntities.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateWebEntities.fs
@@ -104,6 +104,7 @@ let getResultDef a =
   match a.specialType with
   | SpecialType.EntityReference -> getEntityRefDef guidName a
   | SpecialType.Money -> name, [ a, vType, None; currencyId, TsType.String, Some guidName ]
+  | SpecialType.Decimal -> name, [a, TsType.Number, None]
   | _ -> name, [ a, vType, None ]
 
 (** Variable functions *)

--- a/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
+++ b/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
@@ -16,6 +16,7 @@ type SpecialType =
   | Money 
   | Guid 
   | EntityReference
+  | Decimal
 
 type XrmAttribute = { 
   schemaName: string
@@ -120,4 +121,3 @@ type InterpretedState = {
   forms: XrmForm[]
   bpfControls: Map<string,ControlField list>
 }
-

--- a/src/XrmDefinitelyTyped/Interpretation/InterpretEntityMetadata.fs
+++ b/src/XrmDefinitelyTyped/Interpretation/InterpretEntityMetadata.fs
@@ -15,16 +15,14 @@ let toSome convertFunc (nullable:System.Nullable<'a>) =
 let typeConv = function   
   | AttributeTypeCode.Boolean   -> TsType.Boolean
   | AttributeTypeCode.DateTime  -> TsType.Date
-  | AttributeTypeCode.Integer   -> TsType.Number
     
   | AttributeTypeCode.Memo      
   | AttributeTypeCode.EntityName
-  | AttributeTypeCode.Double    
-  | AttributeTypeCode.Decimal   
   | AttributeTypeCode.String    -> TsType.String
 
-  | AttributeTypeCode.BigInt    
   | AttributeTypeCode.Integer
+  | AttributeTypeCode.Double  
+  | AttributeTypeCode.BigInt    
   | AttributeTypeCode.Money     
   | AttributeTypeCode.Picklist  
   | AttributeTypeCode.State     
@@ -65,6 +63,8 @@ let interpretAttribute map entityNames (a:AttributeMetadata) =
     | AttributeTypeCode.Owner     -> TsType.String, SpecialType.EntityReference
         
     | AttributeTypeCode.Uniqueidentifier -> TsType.String, SpecialType.Guid
+    | AttributeTypeCode.Decimal   -> 
+      toSome typeConv a.AttributeType, SpecialType.Decimal
     | _ -> toSome typeConv a.AttributeType, SpecialType.Default
 
   let attr = 


### PR DESCRIPTION
The Decimal attribute was causing problems as the Web api only allowed the attribute to be updated with a Number type while the Rest api only allowed a String type. As the two api can not share the same type I have added decimal as a special attribute type. This allow the attribute to be converted in the later stage when the Rest and Web entities are created. Allowing the two api's to have their own TS type for Decimal attributes.

I have also changed the type convertion of Integer and Double attributes to produce TS Number type instead of String type for both Rest and Web Entites. Before the attributes where submitted and retrieved as string. However, when fetched from CRM the underlying type is a Number. Which meant that it was not possible to work on attribute as a string unless .toString() was called first.