### PR TITLE
Add new crm 365 extension file for 8.2 and methods for handling autocomplete

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
@@ -1,0 +1,101 @@
+﻿/// <reference path="..\xrm.d.ts" />
+declare namespace Xrm {
+  /**
+   * Interface for a single result in the auto-completion list.
+   */
+  interface AutoCompleteResult {
+    /**
+     * Unique id for the result
+     */
+    id: string;
+    /**
+     * Result icon defined by an image url
+     */
+    icon: string;
+    /**
+     * Values to display in the result. Support up to three values
+     */
+    fields: string[]
+  }
+
+  /**
+   * Interface for a command button in lower right corner of the auto-completion drop-down list.
+   */
+  interface AutoCompleteCommand {
+    /**
+     * Unique id for the command
+     */
+    id: string;
+    /**
+     * Command icon defined by an image url
+     */
+    icon: string;
+    /**
+     * Label for the command
+     */
+    label: string;
+    /**
+     * Command action
+     */
+    action: () => any
+  }
+
+  /**
+   * Interface for the result set to be shown in auto-completion list.
+   */
+  interface AutoCompleteResultSet {
+    /**
+     * List of returned results
+     */
+    results: AutoCompleteResult[];
+    /**
+     * Command at the bottom of the auto-completion drop-down list (optional)
+     */
+    commands: AutoCompleteCommand;
+  }
+
+  interface StringControl extends Control<Attribute<string>> {
+    /**
+     * Gets the latest value in a control as the user types characters in a specific text or number field.
+     * The getValue method is different from the attribute getValue method because the control method retrieves the value from the control as the user is typing in the control as opposed to the attribute getValue method that retrieves the value after the user commits (saves) the field.
+     */
+    getValue(): string;
+
+    /**
+     * Use this to add a function as an event handler for the keypress event so that the function is called when you type a character in the specific text field.
+     * You should use reference to a named function rather than an anonymous function if you may later want to remove the event handler for the field.
+     *
+     * @param functionRef The event handler for the OnKeyPressed event.
+     */
+    addOnKeyPress(functionRef: (context?: ExecutionContext<this>) => any): void;
+
+    /**
+     * Use this to remove an event handler for a text field that you added using addOnKeyPress.
+     *
+     * @param functionRef The event handler for the OnKeyPressed event.
+     */
+    removeOnKeyPress(functionRef: Function): void;
+
+    /**
+     * Use this to manually fire an event handler that you created for a specific text field to be executed on the keypress event.
+     */
+    fireOnKeyPress(): void;
+
+    /**
+     * Use this to show up to 10 matching strings in a drop-down list as users press keys to type character in a specific text field.
+     * You can also add a custom command with an icon at the bottom of the drop-down list.
+     * On selecting an item in the drop-down list, the value in the text field changes to the selected item, the drop-down list disappears, and the OnChange event for the text field is invoked.
+     * This methods isn’t supported for Dynamics 365 mobile clients (phones or tablets) and the interactive service hub. This methods are only available for Updated entities.
+     *
+     * @param resultSet to be shown in 
+     */
+    showAutoComplete(resultSet: AutoCompleteResultSet): void;
+
+    /**
+     * Use this function to hide the auto-completion drop-down list you configured for a specific text field.
+     * You don’t have to explicitly use the hideAutoComplete method because, by default, the drop-down list hides automatically if the user clicks elsewhere or if a new drop-down list is displayed.
+     * * This methods isn’t supported for Dynamics 365 mobile clients (phones or tablets) and the interactive service hub. This methods are only available for Updated entities.
+     */
+    hideAutoComplete(): void;
+  }
+}

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
@@ -76,6 +76,7 @@
     <EmbeddedResource Include="Resources\Extensions\xrm_ext_-7.d.ts" />
     <EmbeddedResource Include="Resources\Extensions\xrm_ext_7.1-.d.ts" />
     <EmbeddedResource Include="Resources\Extensions\xrm_ext_8-.d.ts" />
+    <EmbeddedResource Include="Resources\Extensions\xrm_ext_8.2-.d.ts" />
     <EmbeddedResource Include="Resources\_internal\sdk.d.ts" />
     <EmbeddedResource Include="Resources\Dist\dg.xrmquery.rest.d.ts" />
     <EmbeddedResource Include="Resources\Dist\dg.xrmquery.rest.js">


### PR DESCRIPTION
A large amount of new form methods have been added with crm 365. I have added a new extension file for version 8.2 and up that adds new methods for working with auto-completion on string control. This include:

- getValue
- addOnKeypress
- removeOnKeypress
- fireOnKeyPress
- showAutoComplete
- hideAutoComplete

This pull request does not include all new methods added in 365
