### PR TITLE
Fixes #59

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -128,7 +128,7 @@ namespace XrmQuery {
 	 * @param configure Modify the request before it it sent to the endpoint - like adding headers.
 	 */
   export function sendRequest(type: XQW.HttpRequestType, queryString: string, data: any, successCb: (x: XMLHttpRequest) => any, errorCb?: (err: Error) => any, configure?: (req: XMLHttpRequest) => void): void {
-    request(type, encodeURI(XQW.getApiUrl() + queryString), data, successCb, errorCb, configure);
+    request(type, XQW.getApiUrl() + queryString, data, successCb, errorCb, configure);
   }
 
 	/**
@@ -174,9 +174,9 @@ namespace Filter {
 	 */
   function getVal(v: any) {
     if (v == null) return "null"
-    if (typeof v === "string") return `'${v}'`;
-    if (v instanceof Date) return v.toISOString();
-    return v.toString();
+    if (typeof v === "string") return encodeURIComponent(`'${v}'`);
+    if (v instanceof Date) return encodeURIComponent(v.toISOString());
+    return encodeURIComponent(v.toString());
   }
 
 	/**

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -174,30 +174,30 @@ namespace Filter {
 	 */
   function getVal(v: any) {
     if (v == null) return "null"
-    if (typeof v === "string") return encodeURIComponent(`'${v}'`);
-    if (v instanceof Date) return encodeURIComponent(v.toISOString());
-    return encodeURIComponent(v.toString());
+    if (typeof v === "string") return `'${v}'`;
+    if (v instanceof Date) return v.toISOString();
+    return v.toString();
   }
 
 	/**
 	 * @internal
 	 */
   function comp<T>(val1: T, op: string, val2: T): WebFilter {
-    return <WebFilter><any>(`${getVal(val1)} ${op} ${getVal(val2)}`);
+    return <WebFilter><any>(encodeURIComponent(`${getVal(val1)} ${op} ${getVal(val2)}`));
   }
 
 	/**
 	 * @internal
 	 */
   function dataFunc<T>(funcName: string, val1: T, val2: T): WebFilter {
-    return <WebFilter><any>(`${funcName}(${getVal(val1)}, ${getVal(val2)})`);
+    return <WebFilter><any>(encodeURIComponent(`${funcName}(${getVal(val1)}, ${getVal(val2)})`));
   }
 
 	/**
 	 * @internal
 	 */
   function biFilter(f1: WebFilter, conj: string, f2: WebFilter): WebFilter {
-    return <WebFilter><any>(`(${f1} ${conj} ${f2})`);
+    return <WebFilter><any>(encodeURIComponent(`(${f1} ${conj} ${f2})`));
   }
 
 	/**

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -128,7 +128,7 @@ namespace XrmQuery {
 	 * @param configure Modify the request before it it sent to the endpoint - like adding headers.
 	 */
   export function sendRequest(type: XQW.HttpRequestType, queryString: string, data: any, successCb: (x: XMLHttpRequest) => any, errorCb?: (err: Error) => any, configure?: (req: XMLHttpRequest) => void): void {
-    request(type, XQW.getApiUrl() + queryString, data, successCb, errorCb, configure);
+    request(type, encodeSpaces(XQW.getApiUrl() + queryString), data, successCb, errorCb, configure);
   }
 
 	/**
@@ -141,6 +141,10 @@ namespace XrmQuery {
   export function promiseRequest(type: XQW.HttpRequestType, queryString: string, data: any, configure?: (req: XMLHttpRequest) => void): Promise<XMLHttpRequest> {
     return XQW.promisifyCallback((success, error?) => sendRequest(type, queryString, data, success, error, configure));
   }
+
+    function encodeSpaces(str: string): string {
+        return str.replace(/ /g, "%20");
+    }
 }
 
 
@@ -174,30 +178,30 @@ namespace Filter {
 	 */
   function getVal(v: any) {
     if (v == null) return "null"
-    if (typeof v === "string") return `'${v}'`;
-    if (v instanceof Date) return v.toISOString();
-    return v.toString();
+    if (typeof v === "string") return `'${encodeSpecialCharacters(v)}'`;
+    if (v instanceof Date) return encodeSpecialCharacters(v.toISOString());
+    return encodeSpecialCharacters(v.toString());
   }
 
 	/**
 	 * @internal
 	 */
   function comp<T>(val1: T, op: string, val2: T): WebFilter {
-    return <WebFilter><any>(encodeURIComponent(`${getVal(val1)} ${op} ${getVal(val2)}`));
+    return <WebFilter><any>(`${getVal(val1)} ${op} ${getVal(val2)}`);
   }
 
 	/**
 	 * @internal
 	 */
   function dataFunc<T>(funcName: string, val1: T, val2: T): WebFilter {
-    return <WebFilter><any>(encodeURIComponent(`${funcName}(${getVal(val1)}, ${getVal(val2)})`));
+    return <WebFilter><any>(`${funcName}(${getVal(val1)}, ${getVal(val2)})`);
   }
 
 	/**
 	 * @internal
 	 */
   function biFilter(f1: WebFilter, conj: string, f2: WebFilter): WebFilter {
-    return <WebFilter><any>(encodeURIComponent(`(${f1} ${conj} ${f2})`));
+    return <WebFilter><any>(`(${f1} ${conj} ${f2})`);
   }
 
 	/**
@@ -209,6 +213,22 @@ namespace Filter {
       return <WebFilter><any>('');
     }
     return fs.reduceRight((acc, c) => biFilter(c, conj, acc), last);
+  }
+
+    /**
+     * @internal
+     */
+  function encodeSpecialCharacters(queryString: string) {
+    queryString = encodeURI(queryString);
+    queryString = queryString.replace(/'/g, "''");
+
+    queryString = queryString.replace(/\+/g, "%2B");
+    queryString = queryString.replace(/\//g, "%2F");
+    queryString = queryString.replace(/\?/g, "%3F");
+
+    queryString = queryString.replace(/#/g, "%23");
+    queryString = queryString.replace(/&/g, "%26");
+    return queryString;
   }
 }
 
@@ -726,7 +746,7 @@ namespace XQW {
 		 * @param xml The query in FetchXML format
 		 */
     useFetchXml(xml: string): Query<Result[]> {
-      this.specialQuery = `?fetchXml=${encodeURI(xml)}`;
+      this.specialQuery = `?fetchXml=${encodeURIComponent(xml)}`;
       return this;
     }
 

--- a/test/src/tests/XrmQuery/web/object-manipulation/escape-special-characters.ts
+++ b/test/src/tests/XrmQuery/web/object-manipulation/escape-special-characters.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
+import FakeRequests from '../../../common/fakeRequests';
+import * as sinon from 'sinon';
+
+@suite 
+class Web_Retrieve_EscapeSpecialCharacters extends FakeRequests {
+    @test
+    "simple filter with special characters"() {
+
+        var callback = sinon.spy();
+        XrmQuery.retrieveMultiple(x => x.accounts)
+            .filter(x => Filter.equals(x.accountnumber, "*._-~'!()/+@?=:#;,$& %^[]{}<>\"\\|`"))
+            .execute(callback);
+
+        // Check request
+        expect(this.requests.length).to.equal(1);
+        var req = this.requests[0];
+        expect(req.method).to.equal("GET");
+        expect(req.url).to.equal(`accounts?$filter=accountnumber%20eq%20'*._-~''!()%2F%2B@%3F=:%23;,$%26%20%25%5E%5B%5D%7B%7D%3C%3E%22%5C%7C%60'`);
+
+        // Respond with empty result
+        req.respond(200, {}, JSON.stringify({
+            value: [ ]
+        }));
+
+        // Check that null was correctly passed to success-handler
+        sinon.assert.calledWith(callback, []);
+    }
+
+    @test
+    "expand and simple filter with special characters"() {
+        const accountId = "ACCOUNT_ID";
+
+        var callback = sinon.spy();
+        XrmQuery.retrieve(x => x.accounts, accountId)
+            .expand(x => x.contact_customer_accounts, x => [x.fullname],
+                {
+                    filter: x => Filter.equals(x.firstname, "*._-~'!()/+@?=:#;,$& %^[]{}<>\"\\|`")
+                }
+            )
+            .execute(callback);
+
+        // Check request
+        expect(this.requests.length).to.equal(1);
+        var req = this.requests[0];
+        expect(req.method).to.equal("GET");
+        expect(req.url).to.equal(`accounts(${accountId})?$select=contact_customer_accounts&$expand=contact_customer_accounts($select=fullname;$filter=firstname%20eq%20'*._-~''!()%2F%2B@%3F=:%23;,$%26%20%25%5E%5B%5D%7B%7D%3C%3E%22%5C%7C%60')`);
+
+        // Respond with empty result
+        req.respond(200, {}, JSON.stringify({}));
+
+        // Check that null was correctly passed to success-handler
+        sinon.assert.calledWith(callback, {});
+    }
+
+    @test
+    "fetchxml with special characters"() {
+        var callback = sinon.spy();
+        XrmQuery.retrieveMultiple(x => x.accounts)
+            .useFetchXml(`<fetch mapping='logical'><entity name='account'><attribute name='accountid'/><attribute name='name'/><filter><condition attribute="name" operator="eq" value="*._-~&apos;!()/+@?=:#;,$&amp; %^[]{}&lt;&gt;&quot;\\|\`" /></filter></entity></fetch>`)
+            .execute(callback);
+
+        // Check request
+        expect(this.requests.length).to.equal(1);
+        var req = this.requests[0];
+        expect(req.method).to.equal("GET");
+        expect(req.url).to.equal(`accounts?fetchXml=%3Cfetch%20mapping%3D'logical'%3E%3Centity%20name%3D'account'%3E%3Cattribute%20name%3D'accountid'%2F%3E%3Cattribute%20name%3D'name'%2F%3E%3Cfilter%3E%3Ccondition%20attribute%3D%22name%22%20operator%3D%22eq%22%20value%3D%22*._-~%26apos%3B!()%2F%2B%40%3F%3D%3A%23%3B%2C%24%26amp%3B%20%25%5E%5B%5D%7B%7D%26lt%3B%26gt%3B%26quot%3B%5C%7C%60%22%20%2F%3E%3C%2Ffilter%3E%3C%2Fentity%3E%3C%2Ffetch%3E`);
+
+        // Respond with empty result
+        req.respond(200, {}, JSON.stringify({
+            value: []
+        }));
+
+        // Check that null was correctly passed to success-handler
+        sinon.assert.calledWith(callback, []);
+    }
+}

--- a/test/src/tests/XrmQuery/web/query-string/retrieve.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieve.ts
@@ -77,4 +77,16 @@ class Web_Retrieve_QueryString {
         expect(qs).to.equal(`accounts(${this.accountId})?$select=contact_customer_accounts&$expand=contact_customer_accounts($select=fullname;$filter=(firstname eq '${contactFirstName}' and contactid eq ${contactId}))`);
     }
 
+    @test
+    "expand with selects and filters with special characters"() {
+        const qs = XrmQuery.retrieve(x => x.accounts, this.accountId)
+            .expand(x => x.contact_customer_accounts, x => [x.fullname],
+                {
+                    filter: x => Filter.equals(x.firstname, "*._-~'!()/+@?=:#;,$& %^[]{}<>\"\\|`")
+                }
+            )
+            .getQueryString();
+
+        expect(qs).to.equal(`accounts(${this.accountId})?$select=contact_customer_accounts&$expand=contact_customer_accounts($select=fullname;$filter=firstname eq '*._-~''!()%2F%2B@%3F=:%23;,$%26%20%25%5E%5B%5D%7B%7D%3C%3E%22%5C%7C%60')`);
+    }
 }

--- a/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
@@ -58,6 +58,14 @@ class Web_RetrieveMultiple_QueryString {
         expect(qs).to.equal("accounts?$filter=accountnumber eq '12345'");
     }
 
+    @test
+    "simple filter with special characters"() {
+        const qs = XrmQuery.retrieveMultiple(x => x.accounts)
+            .filter(x => Filter.equals(x.accountnumber, "*._-~'!()/+@?=:#;,$& %^[]{}<>\"\\|`"))
+            .getQueryString();
+
+        expect(qs).to.equal("accounts?$filter=accountnumber eq '*._-~''!()%2F%2B@%3F=:%23;,$%26%20%25%5E%5B%5D%7B%7D%3C%3E%22%5C%7C%60'");
+    }
 
     @test 
     "complex filter"() {
@@ -93,16 +101,24 @@ class Web_RetrieveMultiple_QueryString {
         expect(qs).to.equal("accounts?$select=contact_customer_accounts&$expand=contact_customer_accounts($select=fullname,emailaddress1)");
     }
 
-    @test 
+    @test
     "fetchXml"() {
         const qs = XrmQuery.retrieveMultiple(x => x.accounts)
             .useFetchXml(`<fetch mapping='logical'><entity name='account'><attribute name='accountid'/><attribute name='name'/></entity></fetch>`)
             .getQueryString();
 
-        expect(qs).to.equal("accounts?fetchXml=%3Cfetch%20mapping='logical'%3E%3Centity%20name='account'%3E%3Cattribute%20name='accountid'/%3E%3Cattribute%20name='name'/%3E%3C/entity%3E%3C/fetch%3E");
+        expect(qs).to.equal("accounts?fetchXml=%3Cfetch%20mapping%3D'logical'%3E%3Centity%20name%3D'account'%3E%3Cattribute%20name%3D'accountid'%2F%3E%3Cattribute%20name%3D'name'%2F%3E%3C%2Fentity%3E%3C%2Ffetch%3E");
     }
 
+    @test
+    "fetchXml with special characters"() {
+        const qs = XrmQuery.retrieveMultiple(x => x.accounts)
+            .useFetchXml(`<fetch mapping='logical'><entity name='account'><attribute name='accountid'/><attribute name='name'/><filter><condition attribute="name" operator="eq" value="*._-~&apos;!()/+@?=:#;,$&amp; %^[]{}&lt;&gt;&quot;\\|\`" /></filter></entity></fetch>`)
+            .getQueryString();
 
+        expect(qs).to.equal("accounts?fetchXml=%3Cfetch%20mapping%3D'logical'%3E%3Centity%20name%3D'account'%3E%3Cattribute%20name%3D'accountid'%2F%3E%3Cattribute%20name%3D'name'%2F%3E%3Cfilter%3E%3Ccondition%20attribute%3D%22name%22%20operator%3D%22eq%22%20value%3D%22*._-~%26apos%3B!()%2F%2B%40%3F%3D%3A%23%3B%2C%24%26amp%3B%20%25%5E%5B%5D%7B%7D%26lt%3B%26gt%3B%26quot%3B%5C%7C%60%22%20%2F%3E%3C%2Ffilter%3E%3C%2Fentity%3E%3C%2Ffetch%3E");
+    }
+    
     @test 
     "userQuery"() {
         const qs = XrmQuery.retrieveMultiple(x => x.accounts)

--- a/test/src/tests/XrmQuery/web/query-string/retrieveRelatedMultiple.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieveRelatedMultiple.ts
@@ -56,7 +56,7 @@ class Web_RetrieveRelated_QueryString {
             .useFetchXml(`<fetch mapping='logical'><entity name='account'><attribute name='accountid'/><attribute name='name'/></entity></fetch>`)
             .getQueryString();
 
-        expect(qs).to.equal(`accounts(${this.accountId})/account_master_account?fetchXml=%3Cfetch%20mapping='logical'%3E%3Centity%20name='account'%3E%3Cattribute%20name='accountid'/%3E%3Cattribute%20name='name'/%3E%3C/entity%3E%3C/fetch%3E`);
+        expect(qs).to.equal(`accounts(${this.accountId})/account_master_account?fetchXml=%3Cfetch%20mapping%3D'logical'%3E%3Centity%20name%3D'account'%3E%3Cattribute%20name%3D'accountid'%2F%3E%3Cattribute%20name%3D'name'%2F%3E%3C%2Fentity%3E%3C%2Ffetch%3E`);
     }
 
     @test 


### PR DESCRIPTION
Function proposed by Bo doesn't resolve problem. Function can be easy broken by string: "=+". I think the proper way is to encode every parameter provided by developer. I assume that queryString will be properly escaped will be passed directly to XrmQuery.sendRequest.