### PR TITLE
Fixed casing with openInNewWindow in EntityFormOptions

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -329,7 +329,7 @@ declare namespace Xrm {
 		/**
 		* Indicates whether to display form in a new window.
 		*/
-		openInNewwindow?: boolean;
+		openInNewWindow?: boolean;
 
 		/**
 		* Window Position


### PR DESCRIPTION
Fixed case so that it matches the Microsoft documentation for `openForm`. You can find that documentation here: https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/xrm-navigation/openform