### PR TITLE
Xrm.Utility.lookupObjects returns an array of lookups.

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -686,7 +686,7 @@ declare namespace Xrm {
 		* Opens a lookup control to select one or more items.
 		* @param lookupOptions Defines the options for opening the lookup dialog.
 		*/
-		lookupObjects(lookupOptions: LookupOptions): Then<Lookup>;
+		lookupObjects(lookupOptions: LookupOptions): Then<Lookup[]>;
 
 		/**
 		* Refreshes the parent grid containing the specified record.


### PR DESCRIPTION
It's fixed in the documentation:
https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/issues/671
https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/xrm-utility/lookupobjects