### PR TITLE
fix #111 attribute name can contain '_guid'

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1313,11 +1313,13 @@ namespace XQW {
 	 * @param name
 	 */
   function xrmQueryToCrm(name: string) {
-    const idx = name.indexOf(GUID_ENDING);
-    if (idx == -1) return name;
-    return `_${name.substr(0, idx)}_value`;
+    // check if the attribute name ends with '_guid'
+    const endsWithUnderscoreGuid = name.match(/_guid$/);
+    if (!endsWithUnderscoreGuid) 
+      return name;
+    
+    return `_${name.substr(0, endsWithUnderscoreGuid.index)}_value`;
   }
-
 
 	/**
 	 * Helper function to perform tagged execution and mapping to array of selects

--- a/test/src/tests/XrmQuery/web/query-string/retrieve.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieve.ts
@@ -32,6 +32,17 @@ class Web_Retrieve_QueryString {
 
 
     @test
+    "simple select with _guid in attribute name"() {
+        const qs = XrmQuery.retrieve(x => x.accounts, this.accountId)
+            .select(x => [x.name, x.dg_somestringwith_guids])
+            .getQueryString();
+
+        expect(qs).to.equal(`accounts(${this.accountId})?$select=name,dg_somestringwith_guids`);
+    }
+
+
+
+    @test
     "simple expand"() {
         const qs = XrmQuery.retrieve(x => x.accounts, this.accountId)
             .expand(x => x.contact_customer_accounts)

--- a/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
@@ -29,6 +29,19 @@ class Web_RetrieveMultiple_QueryString {
         expect(qs).to.equal("accounts?$select=name,accountnumber");
     }
 
+
+
+    @test 
+    "simple select with _guid in attribute name"() {
+        const qs = XrmQuery.retrieveMultiple(x => x.accounts)
+            .select(x => [x.name, x.dg_somestringwith_guids])
+            .getQueryString();
+
+        expect(qs).to.equal("accounts?$select=name,dg_somestringwith_guids");
+    }
+
+    
+
     @test 
     "multiple query settings"() {
         const qs = XrmQuery.retrieveMultiple(x => x.accounts)


### PR DESCRIPTION
This PR fixes issue #111.

In your test CRM organization you need to create the 'dg_somestringwith_guids' string attribute on the 'account' entity and updated the generated code. I now added it manually, but the field will disappear when the code is regenerated and then the tests will fail. 