### PR TITLE
Added support for function setEntityTypes on lookup control

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -928,7 +928,17 @@ declare namespace Xrm {
      * @param number The value of the option you want to remove.
      */
     removeOption(number: number): void;
-  }
+    }
+
+
+    interface LookupControl<T extends string> extends Control<LookupAttribute<T>> {
+
+        /**
+        * Use this method to set which entity types the lookup control will show the user
+        */
+        setEntityTypes(entityTypes: Array<string>): void;
+
+    }
 }
 
 interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -931,14 +931,12 @@ declare namespace Xrm {
     }
 
 
-    interface LookupControl<T extends string> extends Control<LookupAttribute<T>> {
-
-        /**
-        * Use this method to set which entity types the lookup control will show the user
-        */
-        setEntityTypes(entityTypes: Array<string>): void;
-
-    }
+  interface LookupControl<T extends string> extends Control<LookupAttribute<T>> {
+    /**
+    * Use this method to set which entity types the lookup control will show the user
+    */
+    setEntityTypes(entityTypes: string[]): void;
+  }
 }
 
 interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {


### PR DESCRIPTION
I've updated the support for the setEntityTypes function on a lookup control for version 9 -> 

see documentation here:
https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/controls/setentitytypes