### PR TITLE
Add support for getEntityTypes()

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -936,6 +936,11 @@ declare namespace Xrm {
     * Use this method to set which entity types the lookup control will show the user
     */
     setEntityTypes(entityTypes: string[]): void;
+
+    /**
+    * Use this method to get which entity types the lookup control will show the user
+    */
+    getEntityTypes(): string[];
   }
 }
 


### PR DESCRIPTION
Add support for `getEntityTypes()` for `LookupControl`. Function is missing on XDT build 4.3.10.

Formatted to match #115

See [getEntityTypes (Client API reference))](https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/controls/getentitytypes)