### PR TITLE
No-Content response test

### DIFF
--- a/test/src/tests/XrmQuery/web/promise/promise.ts
+++ b/test/src/tests/XrmQuery/web/promise/promise.ts
@@ -78,4 +78,20 @@ class Web_Retrieve_Promise extends FakeRequests {
         req.respond(200, { 'OData-EntityId': newAccountId }, "");
         expect(result).to.eventually.equal(newAccountId);
     }
+
+    @test
+    "No-Content response"() {
+        var result = XrmQuery.retrieveRelated(x => x.accounts, "0000-SOME-GUID", y => y.parentaccountid)
+        .select(x => [x.createdby_guid])    
+        .promise();
+
+        // Check request
+        expect(this.requests.length).to.equal(1);
+        var req = this.requests[0];
+
+        // Respond and check that body is parsed correctly
+        req.respond(204, {}, "");
+
+        expect(result).to.eventually.deep.equal([]);
+    }
 }

--- a/test/src/tests/XrmQuery/web/promise/promise.ts
+++ b/test/src/tests/XrmQuery/web/promise/promise.ts
@@ -82,7 +82,7 @@ class Web_Retrieve_Promise extends FakeRequests {
     @test
     "No-Content response"() {
         var result = XrmQuery.retrieveRelated(x => x.accounts, "0000-SOME-GUID", y => y.parentaccountid)
-        .select(x => [x.createdby_guid])    
+        .select(x => [x.createdby_guid])
         .promise();
 
         // Check request


### PR DESCRIPTION
This is to demonstrate the issue I reported #134...