### PR TITLE
openForm returns object with savedEntityReference property.

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -399,6 +399,13 @@ declare namespace Xrm {
     confirmed: boolean;
   }
 
+  interface OpenFormResult {
+    /**
+     * Identifies the record displayed or created
+     */
+    savedEntityReference: Lookup[];
+  }
+
   /**
    * Contains methods for multi-page dialogs and task flow, and some methods moved from the Xrm.Utility namespace.
    */
@@ -437,7 +444,7 @@ declare namespace Xrm {
      * @param formParameters A dictionary object that passes extra parameters to the form.
      * See examples at: https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/set-field-values-using-parameters-passed-form
      */
-    openForm(entityFormOptions: EntityFormOptions, formParameters?: any): Then<Lookup | Lookup[]>;
+    openForm(entityFormOptions: EntityFormOptions, formParameters?: any): Then<OpenFormResult | undefined>;
 
     /**
      * Opens a URL, including file URLs.


### PR DESCRIPTION
> The function that will be called when a record is created. This function is passed an object as a parameter. This object has a savedEntityReference property with the following properties to identify the record created:
> 
> entityType: the logical name of the entity.
> 
> id: A string representation of a GUID value for the record.
> 
> name: The primary attribute value of the record created.

via https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/Xrm-Navigation/openForm

Also used this as reference:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/225c60cb41d53f8adce4d25060cf254ea3b9a907/types/xrm/index.d.ts#L4231