### PR TITLE
AlertStrings updated to include title

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -167,9 +167,14 @@ declare namespace Xrm {
     confirmButtonLabel?: string;
 
     /**
-     * Tge message to be displayed in the alert dialog.
+     * The message to be displayed in the alert dialog.
      */
     text: string;
+
+    /**
+     * The title of the alert dialog.
+     */
+    title?: string;
   }
 
   /**


### PR DESCRIPTION
Added title for AlertStrings. This fixes the issue with Typings for Dialogs (Xrm.Navigation).
#142 
 
