### PR TITLE
WebApi execute method returns Fetch API Response object.

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -532,44 +532,7 @@ declare namespace Xrm {
     isAvailableOffline(entityLogicalName: string): boolean;
   }
 
-  type WebApiResponseType = "" | "arraybuffer" | "blob" | "document" | "json" | "text";
-
-  interface WebApiResponse {
-    /**
-     * Response body.
-     */
-    body?: Object;
-
-    /**
-     * Response headers.
-     */
-    headers: Object;
-
-    /**
-     * Indicates whether the request was successful.
-     */
-    ok: boolean;
-
-    /**
-     * Numeric value in the response status code. For example: 200
-     */
-    status: number;
-
-    /**
-     * Description of the response status code. For example: OK
-     */
-    statusText: string;
-
-    /**
-     * Response type. Values are: the empty string (default), "arraybuffer", "blob", "document", "json", and "text".
-     */
-    type: WebApiResponseType;
-
-    /**
-     * Request URL of the action, function, or CRUD request that was sent to the Web API endpoint.
-     */
-    url: string;
-  }
+  interface WebApiResponse extends Response {}
 
   interface WebApiOnline extends WebApiBase {
     /**


### PR DESCRIPTION
Response object in D365 documentation (https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/xrm-webapi/online/execute) virtually same as Response interface from Fetch API (https://developer.mozilla.org/en-US/docs/Web/API/Response).
Debugging in Chrome confirms this idea:
![image](https://user-images.githubusercontent.com/512079/68600991-216e8a80-04ac-11ea-941b-a8ed3821a7fe.png)

WebApiResponse interface could have been removed completely and its usage replaced with Responsem but it has been left intentionally for backward compatibility.

P.S. Also it solves missing json and text methods in WebApiResponse.