### PR TITLE
ExecutionContext rework.

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-.d.ts
@@ -5,7 +5,7 @@ declare namespace Xrm {
      * Add event handlers to this event to run every time the subgrid refreshes.
      * This includes when users sort the values by clicking the column headings.
      */
-    addOnLoad(functionRef: (context?: ExecutionContext<this>) => any): void;
+    addOnLoad(functionRef: (context?: ExecutionContext<this, any>) => any): void;
 
     /**
      * Use this method to get the logical name of the entity data displayed in the grid.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
@@ -88,13 +88,9 @@ declare namespace Xrm {
     getDirection(): ProcessStageChangeDirection;
   }
 
-  interface StageSelectedContext extends ExecutionContext<Stage> {
-    getEventArgs(): StageSelectedEventArguments;
-  }
+  interface StageSelectedContext extends ExecutionContext<Stage, StageSelectedEventArguments> { }
 
-  interface StageChangeContext extends ExecutionContext<Stage> {
-    getEventArgs(): StageChangeEventArguments;
-  }
+  interface StageChangeContext extends ExecutionContext<Stage, StageChangeEventArguments> { }
 
   /**
    * Interface for the business process flow on a form.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
@@ -78,6 +78,23 @@ declare namespace Xrm {
 
   type ProcessStageMoveAnswer = "success" | "crossEntity" | "end" | "invalid" | "dirtyForm";
   type ProcessStageSetAnswer = "crossEntity" | "unreachable" | "dirtyForm" | "invalid";
+  type ProcessStageChangeDirection = "Next" | "Previous";
+
+  interface StageSelectedEventArguments {
+    getStage(): Stage;
+  }
+
+  interface StageChangeEventArguments extends StageSelectedEventArguments {
+    getDirection(): ProcessStageChangeDirection;
+  }
+
+  interface StageSelectedContext extends ExecutionContext<Stage> {
+    getEventArgs(): StageSelectedEventArguments;
+  }
+
+  interface StageChangeContext extends ExecutionContext<Stage> {
+    getEventArgs(): StageChangeEventArguments;
+  }
 
   /**
    * Interface for the business process flow on a form.
@@ -148,14 +165,14 @@ declare namespace Xrm {
      *
      * @param handler The function will be added to the bottom of the event handler pipeline.
      */
-    addOnStageChange(handler: (context?: ExecutionContext<this>) => any): void;
+    addOnStageChange(handler: (context?: StageChangeContext) => any): void;
 
     /**
      * Use this to remove a function as an event handler for the OnStageChange event.
      *
      * @param handler If an anonymous function is set using the addOnStageChange method it cannot be removed using this method.
      */
-    removeOnStageChange(handler: (context?: ExecutionContext<this>) => any): void;
+    removeOnStageChange(handler: (context?: StageChangeContext) => any): void;
 
     /**
      * Use this to add a function as an event handler for the OnStageSelected event so that it will be called when a business process flow stage is selected.
@@ -163,14 +180,14 @@ declare namespace Xrm {
      *
      * @param handler The function will be added to the bottom of the event handler pipeline.
      */
-    addOnStageSelected(handler: (context?: ExecutionContext<this>) => any): void;
+    addOnStageSelected(handler: (context?: StageSelectedContext) => any): void;
 
     /**
      * Use this to remove a function as an event handler for the OnStageSelected event.
      *
      * @param handler If an anonymous function is set using the addOnStageSelected method it cannot be removed using this method.
      */
-    removeOnStageSelected(handler: (context?: ExecutionContext<this>) => any): void;
+    removeOnStageSelected(handler: (context?: StageSelectedContext) => any): void;
 
     /**
      * Progresses to the next stage.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
@@ -102,9 +102,7 @@ declare namespace Xrm {
     getStatus(): ProcessStatus;
   }
 
-  interface ProcessStatusChangeContext extends ExecutionContext<Process> {
-    getEventArgs(): any;
-  }
+  interface ProcessStatusChangeContext extends ExecutionContext<Process, any> { }
 
   interface ProcessModule {
     /**

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
@@ -102,6 +102,10 @@ declare namespace Xrm {
     getStatus(): ProcessStatus;
   }
 
+  interface ProcessStatusChangeContext extends ExecutionContext<Process> {
+    getEventArgs(): any;
+  }
+
   interface ProcessModule {
     /**
      * Use this to add a function as an event handler for the OnProcessStatusChange event so that it will be called when the
@@ -113,14 +117,14 @@ declare namespace Xrm {
      *                anonymous function if you may later want to remove the
      *                event handler.
      */
-    addOnProcessStatusChange(handler: (context?: ExecutionContext<this>) => any): void;
+    addOnProcessStatusChange(handler: (context?: ProcessStatusChangeContext) => any): void;
 
     /**
      * Use this to remove a function as an event handler for the OnProcessStatusChange event.
      * @param handler If an anonymous function is set using the addOnProcessStatusChange method it
      *                cannot be removed using this method.
      */
-    removeOnProcessStatusChange(handler: (context?: ExecutionContext<this>) => any): void;
+    removeOnProcessStatusChange(handler: (context?: ProcessStatusChangeContext) => any): void;
 
     /**
      * Returns the unique identifier of the process instance.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -701,9 +701,7 @@ declare namespace Xrm {
     /**
      * Form executionContext
      */
-    interface ExecutionContext<T> {
-        getUrl(): string;
-
+    interface ExecutionContext<TSource, TArgs> {
         getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>;
     }
 
@@ -714,6 +712,8 @@ declare namespace Xrm {
          */
         saveMode?: SaveMode;
     }
+
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, any> { }
 
     /**
      * Interface for the data of a form.
@@ -727,7 +727,7 @@ declare namespace Xrm {
         /**
          * Adds a function to be called when form data is loaded.
          */
-        addOnLoad(myFunction: (context?: ExecutionContext<this>) => any): void;
+        addOnLoad(myFunction: (context?: OnLoadEventContext) => any): void;
 
         /**
          * Gets a boolean value indicating whether the form data has been modified.
@@ -803,7 +803,7 @@ declare namespace Xrm {
          * @param myFunction The function to be executed on the form OnLoad event. The function will be added to the bottom of the event handler pipeline.
          * The execution context is automatically passed as the first parameter to the function. See Execution context for more information.
          */
-        addOnLoad(myFunction: (context?: ExecutionContext<this>) => any): void;
+        addOnLoad(myFunction: (context?: OnLoadEventContext) => any): void;
 
         /**
          * Removes a function from the form OnLoad event.

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -590,7 +590,7 @@
      * @param functionRef Reference to a function. It will be added to the bottom of the event handler pipeline.
      *                  The execution context is automatically set to be passed as the first parameter passed to event handlers set using this method.
      */
-    addOnSave(functionRef: (context?: ExecutionContext<this>) => any): void;
+    addOnSave(functionRef: (context?: SaveEventContext<this>) => any): void;
 
     /**
      * Removes a function to be called when the record is saved.
@@ -632,11 +632,6 @@
     getDepth(): number;
 
     /**
-     * Method that returns an object with methods to manage the Save event.
-     */
-    getEventArgs(): SaveEventArgs;
-
-    /**
      * Method that returns a reference to the object that the event occurred on.
      */
     getEventSource(): T;
@@ -655,6 +650,13 @@
      * @param key Key for the desired value
      */
     getSharedVariable(key: string): any;
+  }
+
+  interface SaveEventContext<T> extends ExecutionContext<T> {
+    /**
+     * Method that returns an object with methods to manage the Save event.
+     */
+    getEventArgs(): SaveEventArgs;
   }
 
   interface SaveEventArgs {

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -233,7 +233,7 @@
      *
      * @param functionRef The event handler for the on change event.
      */
-    addOnChange(functionRef: (context?: ExecutionContext<this>) => any): void;
+    addOnChange(functionRef: (context?: ExecutionContext<this, undefined>) => any): void;
 
     /**
      * Removes a function from the OnChange event hander for an attribute.
@@ -620,7 +620,7 @@
     getIsDirty(): boolean;
   }
 
-  interface ExecutionContext<T> {
+  interface ExecutionContext<TSource, TArgs> {
     /**
      * Method that returns the Client-side context object
      */
@@ -632,9 +632,14 @@
     getDepth(): number;
 
     /**
+     * Method that returns an object with methods to manage the Save event.
+     */
+    getEventArgs(): TArgs;
+
+    /**
      * Method that returns a reference to the object that the event occurred on.
      */
-    getEventSource(): T;
+    getEventSource(): TSource;
 
     /**
      * Sets the value of a variable to be used by a handler after the current handler completes.
@@ -652,12 +657,7 @@
     getSharedVariable(key: string): any;
   }
 
-  interface SaveEventContext<T> extends ExecutionContext<T> {
-    /**
-     * Method that returns an object with methods to manage the Save event.
-     */
-    getEventArgs(): SaveEventArgs;
-  }
+  interface SaveEventContext<T> extends ExecutionContext<T, SaveEventArgs> { }
 
   interface SaveEventArgs {
     /**
@@ -1098,6 +1098,11 @@
      * UI of the page.
      */
     ui: Xrm.UiModule<U, V>;
+
+    /**
+     * Returns string with current page URL.
+     */
+    getUrl(): string;
   }
 
   /**


### PR DESCRIPTION
There were missing process related typings at first. As I was adding them it turned out that getEventArgs and getEventSource return different types depending on the actual raised event. PowerApps documentation seems incomplete for many scenarios. I've mined next details through debugging:

Event | Source Type | Args Type
--- | --- | ---
Attribute OnChange | Attribute | undefined
Form OnLoad | UiModule | any?
OnStageChange | Stage | StageChangeEventArguments (new)
OnStageSelected | Stage | StageSelectedEventArguments (new)
OnProcessStatusChange | Process | any?
Form OnSave | PageEntity | SaveEventArgs

I left any because there is some object with methods but they aren't documented anywhere.
Also getUrl isn't member of ExecutionContext. It is on the Page.

Generic ExecutionContext with additional type parameter for getEventArgs fits nice in type definitions. At the same time it brings breaking changes. Anyway I haven't found a way to make it backwards compatible.
