### PR TITLE
160 retrieving fieldnames

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -969,11 +969,19 @@ namespace XQW {
     }
 
     getQueryString(): string {
+      let prefix = `${this.entitySetName}(${this.id})`;
+      let entitySingularName = this.entitySetName.slice(0, -1);
+
       let options: string[] = [];
-      if (this.selects.length > 0) options.push("$select=" + this.selects.join(","));
+      if (this.selects.length > 0) {
+        for (let i in this.selects) {
+          if (this.selects[i] == entitySingularName) this.selects[i] += 1;
+        }
+        options.push("$select=" + this.selects.join(","));
+      }
+
       if (this.expands.length > 0) options.push("$expand=" + this.expands.join(","));
 
-      let prefix = `${this.entitySetName}(${this.id})`;
       if (this.relatedNav) {
         prefix += `/${this.relatedNav}`;
       }

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -697,13 +697,20 @@ namespace XQW {
 
     getQueryString(): string {
       let prefix = this.entitySetName;
+      let entitySingularName = prefix.slice(0, -1);
+
       if (this.id && this.relatedNav) {
         prefix += `(${this.id})/${this.relatedNav}`;
       }
       if (this.specialQuery) return prefix + this.specialQuery;
 
       let options: string[] = [];
+
       if (this.selects.length > 0) {
+        for (let i in this.selects) {
+          if (this.selects[i] == entitySingularName) this.selects[i] += "1";
+        }
+
         options.push("$select=" + this.selects.join(","));
       }
       if (this.expands.length > 0) {

--- a/test/src/tests/XrmQuery/web/query-string/retrieve.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieve.ts
@@ -6,9 +6,11 @@ import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
 class Web_Retrieve_QueryString {
 
     accountId: string;
+    responseId: string;
 
     before() {
         this.accountId = "ACCOUNT_ID";
+        this.responseId = "RESPONSE_ID";
     }
 
     @test
@@ -100,5 +102,23 @@ class Web_Retrieve_QueryString {
             .getQueryString();
 
         expect(qs).to.equal(`accounts(${this.accountId})?$expand=contact_customer_accounts($select=fullname;$filter=firstname eq '*._-~''!()%2F%2B@%3F=:%23;,$%26%20%25%5E%5B%5D%7B%7D%3C%3E%22%5C%7C%60')`);
+    }
+
+    @test
+    "select when field name is same as entity name"() {
+        const qs = XrmQuery.retrieve(x => x.dg_responses, this.responseId)
+            .select(x => [x.dg_response])
+            .getQueryString();
+            
+        expect(qs).to.equal(`dg_responses(${this.responseId})?$select=dg_response1`);
+    }   
+
+    @test
+    "select multiple when one field name is same as entity name"() {
+        const qs = XrmQuery.retrieve(x => x.dg_responses, this.responseId)
+            .select(x => [x.dg_name, x.dg_response])
+            .getQueryString();
+            
+        expect(qs).to.equal(`dg_responses(${this.responseId})?$select=dg_name,dg_response1`);
     }
 }

--- a/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
+++ b/test/src/tests/XrmQuery/web/query-string/retrieveMultiple.ts
@@ -150,4 +150,22 @@ class Web_RetrieveMultiple_QueryString {
 
         expect(qs).to.equal(`accounts?savedQuery=${this.viewId}`);
     }
+
+    @test
+    "select field with same name as entity"() {
+        const qs = XrmQuery.retrieveMultiple(x => x.dg_responses)
+        .select(x => [x.dg_response])
+        .getQueryString();
+
+        expect(qs).to.equal('dg_responses?$select=dg_response1');
+    }
+
+    @test
+    "select multiple fields one with same name as entity"() {
+        const qs = XrmQuery.retrieveMultiple(x => x.dg_responses)
+            .select(x => [x.dg_name, x.dg_response])
+            .getQueryString()
+
+        expect(qs).to.equal('dg_responses?$select=dg_name,dg_response1');
+    }
 }


### PR DESCRIPTION
Xrm query strings are now correctly generated when the selected field name is the same as the entity name. Solves #160 