### PR TITLE
Update getClientUrl function to support Xrm.Utility

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1328,7 +1328,7 @@ namespace XQW {
         return Xrm.Page.context.getClientUrl();
       }
     } catch (e) {}
-    debugger; throw new Error("Context is not available.");
+    throw new Error("Context is not available.");
   }
 
   /**

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1305,30 +1305,62 @@ namespace XQW {
    * @internal
    */
   function getClientUrl() {
+    const url = getClientUrlFromGlobalContext()
+      || getClientUrlFromUtility()
+      || getClientUrlFromXrmPage()
+
+    if (url) {
+      return url;
+    }
+    
+    throw new Error("Context is not available.");
+  }
+
+  /**
+   * @internal
+   */
+  function getClientUrlFromGlobalContext() {
     try {
       if (GetGlobalContext && GetGlobalContext().getClientUrl) {
-        return GetGlobalContext().getClientUrl();
+        return GetGlobalContext().getClientUrl() as string;
       }
     } catch (e) {}
+
+    return undefined;
+  }
+
+  /**
+   * @internal
+   */
+  function getClientUrlFromUtility() {
     try {
       if (Xrm && Xrm.Utility && Xrm.Utility.getGlobalContext) {
-        return Xrm.Utility.getGlobalContext().getClientUrl();
+        return Xrm.Utility.getGlobalContext().getClientUrl() as string;
       }
     } catch (e) {}
     try {
       if (window && window.parent && window.parent.window) {
         const w = <typeof window & { Xrm: any; }>(window.parent.window);
         if (w && w.Xrm && w.Xrm.Utility && w.Xrm.Utility.getGlobalContext) {
-          return w.Xrm.Utility.getGlobalContext().getClientUrl();
+          return w.Xrm.Utility.getGlobalContext().getClientUrl() as string;
         }
       }
     } catch (e) {}
+
+    return undefined;
+  }
+
+  /**
+   * @internal
+   */
+  function getClientUrlFromXrmPage() {
     try {
       if (Xrm && Xrm.Page && Xrm.Page.context) {
-        return Xrm.Page.context.getClientUrl();
+        return Xrm.Page.context.getClientUrl() as string;
       }
     } catch (e) {}
-    throw new Error("Context is not available.");
+
+    return undefined;
   }
 
   /**

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1311,6 +1311,11 @@ namespace XQW {
       }
     } catch (e) {}
     try {
+      if (Xrm && Xrm.Utility && Xrm.Utility.getGlobalContext) {
+        return Xrm.Utility.getGlobalContext().getClientUrl();
+      }
+    } catch (e) {}
+    try {
       if (window && window.parent && window.parent.window) {
         const w = <typeof window & { Xrm: any; }>(window.parent.window)
         if (w && w.Xrm && w.Xrm.Utility && w.Xrm.Utility.getGlobalContext) {

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1307,12 +1307,12 @@ namespace XQW {
   function getClientUrl() {
     const url = getClientUrlFromGlobalContext()
       || getClientUrlFromUtility()
-      || getClientUrlFromXrmPage()
+      || getClientUrlFromXrmPage();
 
     if (url) {
       return url;
     }
-    
+
     throw new Error("Context is not available.");
   }
 

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1317,7 +1317,7 @@ namespace XQW {
     } catch (e) {}
     try {
       if (window && window.parent && window.parent.window) {
-        const w = <typeof window & { Xrm: any; }>(window.parent.window)
+        const w = <typeof window & { Xrm: any; }>(window.parent.window);
         if (w && w.Xrm && w.Xrm.Utility && w.Xrm.Utility.getGlobalContext) {
           return w.Xrm.Utility.getGlobalContext().getClientUrl();
         }

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1305,13 +1305,12 @@ namespace XQW {
    * @internal
    */
   function getClientUrl() {
-    const url = getClientUrlFromGlobalContext()
-      || getClientUrlFromUtility()
-      || getClientUrlFromXrmPage();
-
-    if (url) {
-      return url;
-    }
+    let url = getClientUrlFromGlobalContext();
+    if (url !== undefined) return url;
+    url = getClientUrlFromUtility();
+    if (url !== undefined) return url;
+    url = getClientUrlFromXrmPage();
+    if (url !== undefined) return url;
 
     throw new Error("Context is not available.");
   }

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1311,11 +1311,19 @@ namespace XQW {
       }
     } catch (e) {}
     try {
+      if (window && window.parent && window.parent.window) {
+        const w = <typeof window & { Xrm: any; }>(window.parent.window)
+        if (w && w.Xrm && w.Xrm.Utility && w.Xrm.Utility.getGlobalContext) {
+          return w.Xrm.Utility.getGlobalContext().getClientUrl();
+        }
+      }
+    } catch (e) {}
+    try {
       if (Xrm && Xrm.Page && Xrm.Page.context) {
         return Xrm.Page.context.getClientUrl();
       }
     } catch (e) {}
-    throw new Error("Context is not available.");
+    debugger; throw new Error("Context is not available.");
   }
 
   /**


### PR DESCRIPTION
Since Xrm.Page is [deprecated and due for removal](https://docs.microsoft.com/en-us/power-platform/important-changes-coming#:~:text=Xrm.Utility.getGlobalContext), we should not rely on it to get the ClientUrl.

Added trying to get ClientUrl from `Xrm.Utility`, if possible, and alternatively `window.parent.window.Xrm.Utility` for embedded resources.