### PR TITLE
typings for onlookuptagclick and onload event args

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -945,8 +945,6 @@ declare namespace Xrm {
         saveMode?: SaveMode;
     }
 
-    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, any> { }
-
     /**
      * Interface for the data of a form.
      */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
@@ -7,4 +7,6 @@ declare namespace Xrm {
          */
         securityRoles: string[];
     }
+
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, any> { }
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -31,4 +31,57 @@ declare namespace Xrm {
          */
         setIsValid(bool: boolean, message?: string): void;
     }
+
+    const enum LoadState {
+        InitialLoad = 1,
+        Save = 2,
+        Refresh = 3,
+    }
+
+    interface LoadEventArgs {
+        /**
+         * Gets the state of the data load.
+         */
+        getDataLoadState(): LoadState;
+    }
+
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, LoadEventArgs> { }
+
+    interface LookupTagValue extends Lookup {
+        /**
+         * The originating lookup field that raised the event.
+         */
+        fieldName: string;
+    }
+
+    interface OnLookupTagClickEventArgs {
+        /**
+         * Gets the selected tag value.
+         */
+        getTagValue(): LookupTagValue;
+
+        /**
+        * Returns a value indicating whether the lookup tag click event has been canceled because the preventDefault method was used in this event hander or a previous event handler.
+        */
+        isDefaultPrevented(): boolean;
+
+        /**
+         * Cancels the lookup tag click event, but all remaining handlers for the event will still be executed.
+         */
+        preventDefault(): void;
+    }
+
+    interface OnLookupTagClickContext extends ExecutionContext<any, OnLookupTagClickEventArgs> { }
+
+    interface LookupControl<T extends string> extends Control<LookupAttribute<T>> {
+        /**
+        * Adds an event handler to the OnLookupTagClick event.
+        */
+        addOnLookupTagClick(myFunction: (context?: OnLookupTagClickContext) => any): void;
+
+        /**
+        * Removes an event handler from the OnLookupTagClick event.
+        */
+        removeOnLookupTagClick(functionRef: Function): void;
+    }
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -61,8 +61,8 @@ declare namespace Xrm {
         getTagValue(): LookupTagValue;
 
         /**
-        * Returns a value indicating whether the lookup tag click event has been canceled because the preventDefault method was used in this event hander or a previous event handler.
-        */
+         * Returns a value indicating whether the lookup tag click event has been canceled because the preventDefault method was used in this event hander or a previous event handler.
+         */
         isDefaultPrevented(): boolean;
 
         /**
@@ -75,13 +75,13 @@ declare namespace Xrm {
 
     interface LookupControl<T extends string> extends Control<LookupAttribute<T>> {
         /**
-        * Adds an event handler to the OnLookupTagClick event.
-        */
+         * Adds an event handler to the OnLookupTagClick event.
+         */
         addOnLookupTagClick(myFunction: (context?: OnLookupTagClickContext) => any): void;
 
         /**
-        * Removes an event handler from the OnLookupTagClick event.
-        */
+         * Removes an event handler from the OnLookupTagClick event.
+         */
         removeOnLookupTagClick(functionRef: Function): void;
     }
 }


### PR DESCRIPTION
- https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/executioncontext/geteventargs
- https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/events/onlookuptagclick

Not entirely sure when the getDataLoadState was added so I added it to >= 9.1 file.