### PR TITLE
Formitem setvisible

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -84,4 +84,11 @@ declare namespace Xrm {
          */
         removeOnLookupTagClick(functionRef: Function): void;
     }
+
+    interface FormItem {
+        /**
+        * Sets a value that indicates whether the control is visible.
+        */
+        setVisible(visibility: boolean): void;
+    }
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -87,8 +87,8 @@ declare namespace Xrm {
 
     interface FormItem {
         /**
-        * Sets a value that indicates whether the control is visible.
-        */
+         * Sets a value that indicates whether the control is visible.
+         */
         setVisible(visibility: boolean): void;
     }
 }

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -1023,7 +1023,12 @@
     /**
      * Opens the specified form.
      */
-    navigate(): void;
+      navigate(): void;
+
+    /**
+    * Sets a value that indicates whether the control is visible.
+    */
+    setVisible(visibility: boolean): void;
   }
 
   interface navigation {

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -1026,8 +1026,8 @@
     navigate(): void;
 
     /**
-    * Sets a value that indicates whether the control is visible.
-    */
+     * Sets a value that indicates whether the control is visible.
+     */
     setVisible(visibility: boolean): void;
   }
 

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -1024,11 +1024,6 @@
      * Opens the specified form.
      */
     navigate(): void;
-
-    /**
-     * Sets a value that indicates whether the control is visible.
-     */
-    setVisible(visibility: boolean): void;
   }
 
   interface navigation {

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -1024,6 +1024,11 @@
      * Opens the specified form.
      */
     navigate(): void;
+
+    /**
+    * Sets a value that indicates whether the control is visible.
+    */
+    setVisible(visibility: boolean): void;
   }
 
   interface navigation {


### PR DESCRIPTION
Fix for missing setVisible method on FormItem, which is an officialyl supported API by Microsoft:

https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/formcontext-ui-formselector/setvisible