### PR TITLE
Added title optional property to the NavigationOptions interface

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -558,6 +558,11 @@ declare namespace Xrm {
          * Number. Specify 1 to open the dialog in center; 2 to open the dialog on the side. Default is 1 (center).
          */
         position?: NavigationOptionsPosition;
+
+        /**
+         * String. The dialog title on top of the center or side dialog.
+         */
+        title?: string;
     }
 
     /**


### PR DESCRIPTION
Added missing title property to NavigationOptions interface.

Screenshot from the documentation
![image](https://user-images.githubusercontent.com/33094487/112548777-319fb500-8dd6-11eb-90d9-800e989f3541.png)
