### PR TITLE
Added support for installing XrmDefinitelyTyped as a PackageReference

### DIFF
--- a/nuget/Delegate.XrmDefinitelyTyped.nuspec
+++ b/nuget/Delegate.XrmDefinitelyTyped.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">    
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>@project@</id>
     <version>@build.number@</version>
     <authors>@authors@</authors>
@@ -11,15 +11,10 @@
     <iconUrl>https://raw.githubusercontent.com/delegateas/delegateas.github.io/master/img/XrmDefinitelyTyped-sticker_small.png</iconUrl>
     <projectUrl>http://delegateas.github.io/</projectUrl>
     <releaseNotes>@releaseNotes@</releaseNotes>
-    <copyright>@copyright@</copyright>    
+    <copyright>@copyright@</copyright>
     <tags>@tags@</tags>
     <contentFiles>
-      <files include="any\any\XrmDefinitelyTyped\Run.ps1" buildAction="None" />
-      <files include="any\any\XrmDefinitelyTyped\Run.fsx" buildAction="None" />
-      <files include="any\any\XrmDefinitelyTyped\XrmDefinitelyTyped.exe.config" buildAction="None" />
-      <files include="any\any\XrmDefinitelyTyped\*.dll" buildAction="Content" />
-      <files include="any\any\XrmDefinitelyTyped\*.exe" buildAction="Content" />
-      <files include="any\any\XrmDefinitelyTyped\XrmDefinitelyTyped.xml" buildAction="Content" />
+      <files include="any\any\XrmDefinitelyTyped\*.*" buildAction="Content" />
     </contentFiles>
     @dependencies@
     @references@
@@ -38,6 +33,6 @@
     <file src="..\files\XrmDefinitelyTyped.exe.config" target="contentFiles\any\any\XrmDefinitelyTyped" />
     <file src="..\src\XrmDefinitelyTyped\bin\Release\*.dll" target="contentFiles\any\any\XrmDefinitelyTyped" />
     <file src="..\src\XrmDefinitelyTyped\bin\Release\*.exe" target="contentFiles\any\any\XrmDefinitelyTyped" />
-    <file src="..\src\XrmDefinitelyTyped\bin\Release\XrmDefinitelyTyped.xml" target="contentFiles\any\any\XrmDefinitelyTyped" />    
+    <file src="..\src\XrmDefinitelyTyped\bin\Release\XrmDefinitelyTyped.xml" target="contentFiles\any\any\XrmDefinitelyTyped" />
   </files>
 </package>

--- a/nuget/Delegate.XrmDefinitelyTyped.nuspec
+++ b/nuget/Delegate.XrmDefinitelyTyped.nuspec
@@ -13,15 +13,31 @@
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>    
     <tags>@tags@</tags>
+    <contentFiles>
+      <files include="any\any\XrmDefinitelyTyped\Run.ps1" buildAction="None" />
+      <files include="any\any\XrmDefinitelyTyped\Run.fsx" buildAction="None" />
+      <files include="any\any\XrmDefinitelyTyped\XrmDefinitelyTyped.exe.config" buildAction="None" />
+      <files include="any\any\XrmDefinitelyTyped\*.dll" buildAction="Content" />
+      <files include="any\any\XrmDefinitelyTyped\*.exe" buildAction="Content" />
+      <files include="any\any\XrmDefinitelyTyped\XrmDefinitelyTyped.xml" buildAction="Content" />
+    </contentFiles>
     @dependencies@
     @references@
   </metadata>
   <files>
+    <!-- content -->
     <file src="..\files\Run.ps1" target="content\XrmDefinitelyTyped" />
     <file src="..\files\Run.fsx" target="content\XrmDefinitelyTyped" />
     <file src="..\files\XrmDefinitelyTyped.exe.config" target="content\XrmDefinitelyTyped" />
     <file src="..\src\XrmDefinitelyTyped\bin\Release\*.dll" target="content\XrmDefinitelyTyped" />
     <file src="..\src\XrmDefinitelyTyped\bin\Release\*.exe" target="content\XrmDefinitelyTyped" />
     <file src="..\src\XrmDefinitelyTyped\bin\Release\XrmDefinitelyTyped.xml" target="content\XrmDefinitelyTyped" />
+    <!-- contentFiles -->
+    <file src="..\files\Run.ps1" target="contentFiles\any\any\XrmDefinitelyTyped" />
+    <file src="..\files\Run.fsx" target="contentFiles\any\any\XrmDefinitelyTyped" />
+    <file src="..\files\XrmDefinitelyTyped.exe.config" target="contentFiles\any\any\XrmDefinitelyTyped" />
+    <file src="..\src\XrmDefinitelyTyped\bin\Release\*.dll" target="contentFiles\any\any\XrmDefinitelyTyped" />
+    <file src="..\src\XrmDefinitelyTyped\bin\Release\*.exe" target="contentFiles\any\any\XrmDefinitelyTyped" />
+    <file src="..\src\XrmDefinitelyTyped\bin\Release\XrmDefinitelyTyped.xml" target="contentFiles\any\any\XrmDefinitelyTyped" />    
   </files>
 </package>

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
@@ -101,10 +101,10 @@
     <None Include="paket.references" />
     <None Include="App.config" />
     <None Include="EnvInfo.config" />
-    <Content Include="bin\Release\$(TargetFramework)\*.dll" Pack="true" PackagePath="content\XrmDefinitelyTyped" />
-    <Content Include="bin\Release\$(TargetFramework)\*.exe" Pack="true" PackagePath="content\XrmDefinitelyTyped" />
-    <Content Include="bin\Release\$(TargetFramework)\XrmDefinitelyTyped.xml" Pack="true" PackagePath="content\XrmDefinitelyTyped" />
-    <Content Include="..\..\files\*" Pack="true" PackagePath="content\XrmDefinitelyTyped" />
+    <Content Include="bin\Release\$(TargetFramework)\*.dll" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
+    <Content Include="bin\Release\$(TargetFramework)\*.exe" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
+    <Content Include="bin\Release\$(TargetFramework)\XrmDefinitelyTyped.xml" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
+    <Content Include="..\..\files\*" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
     <None Include="package.json" />
     <None Include="tsconfig.json" />
     <None Include="gulpfile.js" />


### PR DESCRIPTION
When installing XrmDefinitelyTyped as a PackageReference in an SDK-style project, the XrmDefinitelyTyped files aren't added to the project. This behavior occurs because PackageReferences read from the `contentFiles` instead of `files` in the nuspec / fsproj. 

This change copies the files to both locations allowing the package to work with both old an SDK-style projects.

![image](https://user-images.githubusercontent.com/1784236/116910217-495b2c00-ac13-11eb-8391-5a882b5ab57d.png)
