### PR TITLE
Resolve #252.

### DIFF
--- a/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
+++ b/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
@@ -272,7 +272,7 @@ let generateFormDefs state crmVersion generateMappings =
                     if i = 0 then form
                     else { form with name = sprintf "%s%i" form.name i }))
     |> Array.concat
-    |> Array.filter (fun (form: XrmForm) -> form.formType.IsNone || (form.formType.IsSome && form.formType.Value <> "Card"))
+    |> Array.filter (fun (form: XrmForm) -> form.formType.IsNone || (form.formType.IsSome && form.formType.Value <> "Card" && form.formType.Value <> "InteractionCentricDashboard" && form.formType.Value <> "TaskFlowForm"))
     |> Array.Parallel.map (fun xrmForm -> 
          let path = sprintf "%s/Form/%s%s" state.outputDir xrmForm.entityName (getFormType xrmForm)
          let lines = getFormDts xrmForm crmVersion generateMappings


### PR DESCRIPTION
To resolve #252, ignore the special form types InteractionCentricDashboard and TaskFlowForm when generating form contexts. Neither has any apparent applications,as you can't apply web ressource handlers to them. As they contain attributes and controls that are not mappable.