### PR TITLE
181 override xrm namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 # Release Notes
+### 6.3.0 - July 18 2022
+* Added support for custom Xrm namespace.
+
 ### 6.2.0 - July 8 2022
 * Use overridden API version in OData paths.
 * Switch to eslint

--- a/src/XrmDefinitelyTyped/AssemblyInfo.fs
+++ b/src/XrmDefinitelyTyped/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Tool to generate TypeScript declaration files for MS Dynamics 365/CRM client-side coding.")>]
 [<assembly: AssemblyCompanyAttribute("Delegate A/S")>]
 [<assembly: AssemblyCopyrightAttribute("Copyright (c) Delegate A/S 2017")>]
-[<assembly: AssemblyVersionAttribute("6.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("6.2.0")>]
+[<assembly: AssemblyVersionAttribute("6.3.0")>]
+[<assembly: AssemblyFileVersionAttribute("6.3.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -17,5 +17,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "Tool to generate TypeScript declaration files for MS Dynamics 365/CRM client-side coding."
     let [<Literal>] AssemblyCompany = "Delegate A/S"
     let [<Literal>] AssemblyCopyright = "Copyright (c) Delegate A/S 2017"
-    let [<Literal>] AssemblyVersion = "6.2.0"
-    let [<Literal>] AssemblyFileVersion = "6.2.0"
+    let [<Literal>] AssemblyVersion = "6.3.0"
+    let [<Literal>] AssemblyFileVersion = "6.3.0"

--- a/src/XrmDefinitelyTyped/CommandLine/Arguments.fs
+++ b/src/XrmDefinitelyTyped/CommandLine/Arguments.fs
@@ -100,6 +100,12 @@ type Args private () =
       altCommands=["vi"]
       description="Comma-separated list of named semicolon-separated lists of view GUIDs that should be intersected. "
       required=false }
+
+    { command = "xrmNamespace"
+      altCommands = ["xrmNs"]
+      description = "Namespace to use instead of Xrm."
+      required = false
+    }
   ]
 
   static member connectionArgs = [

--- a/src/XrmDefinitelyTyped/CommandLine/Program.fs
+++ b/src/XrmDefinitelyTyped/CommandLine/Program.fs
@@ -87,6 +87,7 @@ let getGenerationSettings parsedArgs =
     viewIntersects = intersects "viewintersect"
     labelMapping = labelMapping
     generateMappings = getArg parsedArgs "generateMappings" parseBoolish ?| false
+    xrmNs = getArg parsedArgs "xrmNamespace" nsSanitizer ?| "Xrm"
   }
 
 

--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
@@ -212,8 +212,8 @@ let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version) (xrmNs
   
   let delegateFunc =
     Function.Create("getControl",
-      [ Variable.Create("delegateFunction", TsType.Custom("Xrm.Collection.MatchingDelegate<Xrm.Control<any>>"))],
-      TsType.Custom("Xrm.Control<any>[]"))
+      [ Variable.Create("delegateFunction", TsType.Custom(sprintf "%s.Collection.MatchingDelegate<%s.Control<any>>" xrmNs xrmNs))],
+      TsType.Custom(sprintf "%s.Control<any>[]" xrmNs))
   
   ctrlFuncs @ [ defaultFunc; delegateFunc ]
 

--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
@@ -12,18 +12,18 @@ let unionWithNull t canBeNull =
     t
 
 /// Translate internal attribute type to corresponding TypeScript interface.
-let getAttributeInterface ty canBeNull = 
+let getAttributeInterface ty canBeNull xrmNs = 
   let returnType = 
     match ty with
-    | AttributeType.OptionSet ty  -> TsType.SpecificGeneric ("Xrm.OptionSetAttribute", [ ty ])
+    | AttributeType.OptionSet ty  -> TsType.SpecificGeneric (sprintf "%s.OptionSetAttribute" xrmNs, [ ty ])
     | AttributeType.MultiSelectOptionSet ty
-                                -> TsType.SpecificGeneric ("Xrm.MultiSelectOptionSetAttribute", [ ty ])
-    | AttributeType.Default ty    -> TsType.SpecificGeneric ("Xrm.Attribute", [ ty ])
-    | AttributeType.Lookup ty     -> TsType.Custom (sprintf "Xrm.LookupAttribute<%s>" ty)
-    | x                           -> TsType.Custom (sprintf "Xrm.%AAttribute" x)
+                                -> TsType.SpecificGeneric (sprintf "%s.MultiSelectOptionSetAttribute" xrmNs, [ ty ])
+    | AttributeType.Default ty    -> TsType.SpecificGeneric (sprintf "%s.Attribute" xrmNs, [ ty ])
+    | AttributeType.Lookup ty     -> TsType.Custom (sprintf "%s.LookupAttribute<%s>" xrmNs ty)
+    | x                           -> TsType.Custom (sprintf "%s.%AAttribute" xrmNs x)
   unionWithNull returnType canBeNull
 
-let getAttributeMap ty canBeNull = 
+let getAttributeMap ty canBeNull xrmNs = 
   let returnType = 
     match ty with
     | AttributeType.OptionSet ty
@@ -31,7 +31,7 @@ let getAttributeMap ty canBeNull =
     | AttributeType.Default ty    -> ty
     | AttributeType.Number        -> TsType.Number
     | AttributeType.Date          -> TsType.Date
-    | AttributeType.Lookup ty     -> TsType.Custom (sprintf "Xrm.EntityReference<%s>" ty)
+    | AttributeType.Lookup ty     -> TsType.Custom (sprintf "%s.EntityReference<%s>" xrmNs ty)
   unionWithNull returnType canBeNull
  
 /// Gets the corresponding enum of the option set if possible
@@ -41,20 +41,20 @@ let getOptionSetType = function
   | _ -> TsType.Number
 
 /// Translate internal control type to corresponding TypeScript interface.
-let getControlInterface cType aType canBeNull =
+let getControlInterface cType aType canBeNull xrmNs =
   let returnType = 
     match aType, cType with
-    | None, ControlType.Default       -> TsType.Custom "Xrm.BaseControl"
+    | None, ControlType.Default       -> TsType.Custom (sprintf "%s.BaseControl" xrmNs)
     | Some (AttributeType.Default TsType.String), ControlType.Default
-                                      -> TsType.Custom "Xrm.StringControl"
-    | Some at, ControlType.Default    -> TsType.SpecificGeneric ("Xrm.Control", [ getAttributeInterface at canBeNull ]) 
-    | aType, ControlType.OptionSet    -> TsType.SpecificGeneric ("Xrm.OptionSetControl", [ getOptionSetType aType ])
+                                      -> TsType.Custom (sprintf "%s.StringControl" xrmNs)
+    | Some at, ControlType.Default    -> TsType.SpecificGeneric (sprintf "%s.Control" xrmNs, [ getAttributeInterface at canBeNull xrmNs ]) 
+    | aType, ControlType.OptionSet    -> TsType.SpecificGeneric (sprintf "%s.OptionSetControl" xrmNs, [ getOptionSetType aType ])
     | aType, ControlType.MultiSelectOptionSet
-                                      -> TsType.SpecificGeneric ("Xrm.MultiSelectOptionSetControl", [ getOptionSetType aType ])
+                                      -> TsType.SpecificGeneric (sprintf "%s.MultiSelectOptionSetControl" xrmNs, [ getOptionSetType aType ])
     | Some (AttributeType.Lookup _), ControlType.Lookup tes
-    | _, ControlType.Lookup tes       -> TsType.Custom (sprintf "Xrm.LookupControl<%s>" tes)
-    | _, ControlType.SubGrid tes      -> TsType.Custom (sprintf "Xrm.SubGridControl<%s>" tes)
-    | _, x                            -> TsType.Custom (sprintf "Xrm.%AControl" x)
+    | _, ControlType.Lookup tes       -> TsType.Custom (sprintf "%s.LookupControl<%s>" xrmNs tes)
+    | _, ControlType.SubGrid tes      -> TsType.Custom (sprintf "%s.SubGridControl<%s>" xrmNs tes)
+    | _, x                            -> TsType.Custom (sprintf "%s.%AControl" xrmNs x)
   unionWithNull returnType canBeNull
 
 /// Default collection functions which also use the "get" function name.
@@ -75,24 +75,24 @@ let defaultCollectionFuncs defaultType =
 
 
 /// Generate Xrm.Page.data.entity.attributes.get(<string>) functions.
-let getAttributeCollection (attributes: XrmFormAttribute list) =
+let getAttributeCollection (attributes: XrmFormAttribute list) (xrmNs: string) =
   let getFuncs = 
     attributes
     |> List.map (fun (name,ty,canBeNull) ->
       let paramType = getConstantType name
-      let returnType = getAttributeInterface ty canBeNull
+      let returnType = getAttributeInterface ty canBeNull xrmNs
       Function.Create("get", [Variable.Create("name", paramType)], returnType))
 
-  let defaultFuncs = defaultCollectionFuncs "Xrm.Attribute<any>"
-  Interface.Create("Attributes", extends = ["Xrm.AttributeCollectionBase"],
+  let defaultFuncs = defaultCollectionFuncs (sprintf "%s.Attribute<any>" xrmNs)
+  Interface.Create("Attributes", extends = [ sprintf "%s.AttributeCollectionBase" xrmNs],
     funcs = getFuncs @ defaultFuncs)
 
 /// Generate Xrm.Page.data.entity.attributes Map.
-let getAttributeCollectionMap (attributes: XrmFormAttribute list) =
+let getAttributeCollectionMap (attributes: XrmFormAttribute list) (xrmNs: string)=
   let getVars = 
     attributes
     |> List.map (fun (name,ty,canBeNull) ->
-      let returnType = getAttributeMap ty canBeNull
+      let returnType = getAttributeMap ty canBeNull xrmNs
       Variable.Create(name, returnType))
       
   Interface.Create("AttributeValueMap", vars = getVars)
@@ -102,12 +102,12 @@ let includeControl (name: string) crmVersion =
     (not (name.StartsWith("header_")) && not (name.StartsWith("footer_"))) || crmVersion .>= (6,0,0,0)
 
 /// Generate Xrm.Page.ui.controls.get(<string>) functions.
-let getControlCollection (controls: XrmFormControl list) (crmVersion: Version)=
+let getControlCollection (controls: XrmFormControl list) (crmVersion: Version) (xrmNs: string)=
   let getFuncs = 
     controls
     |> List.map (fun (name, aType, cType, isBpf, canBeNull) ->
       let paramType = getConstantType name
-      let returnType = getControlInterface cType aType  canBeNull         
+      let returnType = getControlInterface cType aType canBeNull xrmNs
       match includeControl name crmVersion with
       | false -> None
       | true ->
@@ -115,16 +115,16 @@ let getControlCollection (controls: XrmFormControl list) (crmVersion: Version)=
       )
     |> List.choose id
 
-  let defaultFuncs = defaultCollectionFuncs "Xrm.BaseControl"
-  Interface.Create("Controls", extends = ["Xrm.ControlCollectionBase"],
+  let defaultFuncs = defaultCollectionFuncs (sprintf "%s.BaseControl" xrmNs)
+  Interface.Create("Controls", extends = [ (sprintf "%s.ControlCollectionBase" xrmNs)],
     funcs = getFuncs @ defaultFuncs)
 
 /// Generate Xrm.Page.ui.controls map.
-let getControlCollectionMap (controls: XrmFormControl list) (crmVersion: Version)=
+let getControlCollectionMap (controls: XrmFormControl list) (crmVersion: Version) (xrmNs: string)=
   let getVars = 
     controls
     |> List.map (fun (name, aType, cType, isBpf, canBeNull) ->
-      let returnType = getControlInterface cType aType canBeNull          
+      let returnType = getControlInterface cType aType canBeNull xrmNs        
       match includeControl name crmVersion with
       | false -> None
       | true -> Some (Variable.Create(name, returnType))
@@ -134,45 +134,45 @@ let getControlCollectionMap (controls: XrmFormControl list) (crmVersion: Version
   Interface.Create("ControlMap", vars = getVars)
 
 /// Generate Xrm.Page.ui.tabs.get(<string>) functions.
-let getTabCollection (tabs: XrmFormTab list) =
+let getTabCollection (tabs: XrmFormTab list) (xrmNs: string) =
   let getFuncs =
     tabs
     |> List.map (fun (iname, name, sections) ->
       let paramType = getConstantType name
-      let returnType = sprintf "Xrm.PageTab<Tabs.%s>" iname |> TsType.Custom
+      let returnType = sprintf "%s.PageTab<Tabs.%s>" xrmNs iname |> TsType.Custom
       Function.Create("get", [Variable.Create("name", paramType)], returnType))
 
   let defaultFuncs = 
     defaultCollectionFuncs 
-      "Xrm.PageTab<Xrm.Collection<Xrm.PageSection>>"
+      (sprintf "%s.PageTab<%s.Collection<%s.PageSection>>" xrmNs xrmNs xrmNs)
 
-  Interface.Create("Tabs", extends = ["Xrm.TabCollectionBase"],
+  Interface.Create("Tabs", extends = [(sprintf "%s.TabCollectionBase" xrmNs)],
     funcs = getFuncs @ defaultFuncs)
 
 
 /// Generate Xrm.Page.ui.tabs.get(<someTab>).sections.get(<string>) functions.
-let getSectionCollections (tabs: XrmFormTab list) =
+let getSectionCollections (tabs: XrmFormTab list) (xrmNs: string) =
   let getFuncs sections = 
     sections
     |> List.map (fun name -> 
       let paramType = getConstantType name
       Function.Create("get", [ Variable.Create("name", paramType) ], 
-        TsType.Custom "Xrm.PageSection"))
+        TsType.Custom (sprintf "%s.PageSection" xrmNs)))
 
-  let defaultFuncs = defaultCollectionFuncs "Xrm.PageSection"
+  let defaultFuncs = defaultCollectionFuncs (sprintf "%s.PageSection" xrmNs)
   tabs |> List.map (fun (iname, name, sections) ->
-    Interface.Create(iname, extends = ["Xrm.SectionCollectionBase"],
+    Interface.Create(iname, extends = [(sprintf "%s.SectionCollectionBase" xrmNs)],
       funcs = getFuncs sections @ defaultFuncs))
 
 
 
 /// Generate Xrm.Page.getAttribute(<string>) functions.
-let getAttributeFuncs (attributes: XrmFormAttribute list) =
+let getAttributeFuncs (attributes: XrmFormAttribute list) (xrmNs: string) =
   let attrFuncs = 
     attributes
     |> List.map (fun (name, ty, canBeNull) ->
       let paramType = getConstantType name
-      let returnType = getAttributeInterface ty canBeNull
+      let returnType = getAttributeInterface ty canBeNull xrmNs
       Function.Create("getAttribute", 
         [ Variable.Create("attributeName", paramType) ], returnType))
 
@@ -183,20 +183,20 @@ let getAttributeFuncs (attributes: XrmFormAttribute list) =
   
   let delegateFunc =
       Function.Create("getAttribute",
-        [ Variable.Create("delegateFunction", TsType.Custom("Xrm.Collection.MatchingDelegate<Xrm.Attribute<any>>"))],
-        TsType.Custom("Xrm.Attribute<any>[]"))
+        [ Variable.Create("delegateFunction", TsType.Custom(sprintf "%s.Collection.MatchingDelegate<%s.Attribute<any>>" xrmNs xrmNs))],
+        TsType.Custom(sprintf "%s.Attribute<any>[]" xrmNs))
   
   attrFuncs @ [ defaultFunc; delegateFunc ]
 
 
   
 /// Generate Xrm.Page.getControl(<string>) functions.
-let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version)=
+let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version) (xrmNs: string) =
   let ctrlFuncs = 
     controls
     |> List.map (fun (name, aType, cType, isBpf, canBeNull) ->
       let paramType = getConstantType name
-      let returnType = getControlInterface cType aType canBeNull
+      let returnType = getControlInterface cType aType canBeNull xrmNs
       match includeControl name crmVersion with
       | false -> None
       | true ->
@@ -220,37 +220,37 @@ let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version)=
 
 
 /// Generate internal namespace for keeping track all the collections.
-let getFormNamespace (form: XrmForm) crmVersion generateMappings =
+let getFormNamespace (form: XrmForm) crmVersion generateMappings xrmNs =
   let baseInterfaces =
-    [ getAttributeCollection form.attributes
-      getControlCollection form.controls crmVersion
-      getTabCollection form.tabs ]
+    [ getAttributeCollection form.attributes xrmNs
+      getControlCollection form.controls crmVersion xrmNs
+      getTabCollection form.tabs xrmNs ]
   Namespace.Create(form.name,
     interfaces = 
       (if generateMappings then 
         baseInterfaces @ 
-        [getAttributeCollectionMap form.attributes
-         getControlCollectionMap form.controls crmVersion] 
+        [getAttributeCollectionMap form.attributes xrmNs
+         getControlCollectionMap form.controls crmVersion xrmNs] 
       else baseInterfaces),
     namespaces = 
-      [ Namespace.Create("Tabs", interfaces = getSectionCollections form.tabs) ])
+      [ Namespace.Create("Tabs", interfaces = getSectionCollections form.tabs xrmNs) ])
 
 
 /// Generate the interface for the Xrm.Page of the form.
-let getFormInterface (form: XrmForm) crmVersion =
+let getFormInterface (form: XrmForm) crmVersion (xrmNs : string) =
   let superClass = 
-    sprintf "Xrm.PageBase<%s.Attributes,%s.Tabs,%s.Controls>"
-      form.name form.name form.name
+    sprintf "%s.PageBase<%s.Attributes,%s.Tabs,%s.Controls>"
+      xrmNs form.name form.name form.name
 
   Interface.Create(form.name, extends = [superClass], 
     funcs = 
-      getAttributeFuncs form.attributes @ 
-      getControlFuncs form.controls crmVersion)
+      getAttributeFuncs form.attributes xrmNs @ 
+      getControlFuncs form.controls crmVersion xrmNs)
 
 
 /// Generate the namespace containing all the form interface and internal 
 /// namespaces for collections.
-let getFormDts (form: XrmForm) crmVersion generateMappings = 
+let getFormDts (form: XrmForm) crmVersion xdtSettings = 
   let nsName = 
     sprintf "Form.%s%s" 
       (form.entityName |> Utility.sanitizeString)
@@ -261,7 +261,7 @@ let getFormDts (form: XrmForm) crmVersion generateMappings =
   Namespace.Create(
     nsName,
     declare = true,
-    namespaces = [ getFormNamespace form crmVersion generateMappings],
-    interfaces = [ getFormInterface form crmVersion]) 
+    namespaces = [ getFormNamespace form crmVersion xdtSettings.generateMappings xdtSettings.xrmNs],
+    interfaces = [ getFormInterface form crmVersion xdtSettings.xrmNs]) 
   |> nsToString
 

--- a/src/XrmDefinitelyTyped/Domain.fs
+++ b/src/XrmDefinitelyTyped/Domain.fs
@@ -45,6 +45,7 @@ type XdtGenerationSettings = {
   viewIntersects: Intersect [] option
   labelMapping: (string * string)[] option
   generateMappings: bool
+  xrmNs: string
 }
 
 type EntityName = string

--- a/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
+++ b/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
@@ -91,9 +91,11 @@ let versionExtendFile crmVersion gSettings outputDir (resName,fileName) preffix 
   |> Seq.map (getResourceLines >> stripReferenceLines)
   |> (getResourceLines resName |> Seq.singleton |> Seq.append)
   |> List.concat
+  |> Seq.map (fun l -> l.Replace("#XRMNS#", gSettings.xrmNs))
   |> fun lines -> 
-  File.WriteAllLines(
-    sprintf "%s/%s" outputDir fileName, lines)
+    File.WriteAllLines(
+    sprintf "%s/%s" outputDir fileName, lines
+    )
 
 let generateJSExtResourceFiles crmVersion gSettings =
 
@@ -258,7 +260,7 @@ let generateWebEntityDefs ns state =
   defs
 
 /// Generate the Form definitions
-let generateFormDefs state crmVersion generateMappings = 
+let generateFormDefs state crmVersion xdtSettings = 
   printf "Generation Form definitions..."
   let getFormType xrmForm = xrmForm.formType ?|> sprintf "/%s" ?| ""
   
@@ -275,7 +277,7 @@ let generateFormDefs state crmVersion generateMappings =
     |> Array.filter (fun (form: XrmForm) -> form.formType.IsNone || (form.formType.IsSome && form.formType.Value <> "Card" && form.formType.Value <> "InteractionCentricDashboard" && form.formType.Value <> "TaskFlowForm"))
     |> Array.Parallel.map (fun xrmForm -> 
          let path = sprintf "%s/Form/%s%s" state.outputDir xrmForm.entityName (getFormType xrmForm)
-         let lines = getFormDts xrmForm crmVersion generateMappings
+         let lines = getFormDts xrmForm crmVersion xdtSettings
          sprintf "%s/%s.d.ts" path xrmForm.name, lines)
 
   printfn "Done!"

--- a/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
+++ b/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
@@ -91,7 +91,7 @@ let versionExtendFile crmVersion gSettings outputDir (resName,fileName) preffix 
   |> Seq.map (getResourceLines >> stripReferenceLines)
   |> (getResourceLines resName |> Seq.singleton |> Seq.append)
   |> List.concat
-  |> Seq.map (fun l -> l.Replace("#XRMNS#", gSettings.xrmNs))
+  |> Seq.map (fun l -> l.Replace("_XRMNS_", gSettings.xrmNs))
   |> fun lines -> 
     File.WriteAllLines(
     sprintf "%s/%s" outputDir fileName, lines

--- a/src/XrmDefinitelyTyped/Generation/GenerationMain.fs
+++ b/src/XrmDefinitelyTyped/Generation/GenerationMain.fs
@@ -39,7 +39,7 @@ let generateFromRaw gSettings rawState =
   let defs = 
     seq {
       yield! generateEnumDefs data
-      if not gSettings.skipForms then yield! generateFormDefs data crmVersion gSettings.generateMappings
+      if not gSettings.skipForms then yield! generateFormDefs data crmVersion gSettings
 
       match crmVersion .>= (8,2,0,0) with
       | true -> 

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-6.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-6.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface context {
     /**
      * Returns a Boolean value indicating if the user is using Microsoft Dynamics CRM for Microsoft Office Outlook.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-8.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-8.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   //eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface PageTab<T extends SectionCollectionBase> {
     /**

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
@@ -1,7 +1,7 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
-  let Page: Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>;
+declare namespace _XRMNS_ {
+  let Page: _XRMNS_.PageBase<_XRMNS_.AttributeCollectionBase, _XRMNS_.TabCollectionBase, _XRMNS_.ControlCollectionBase>;
   /**
    * Interface for the base of an Xrm.Page
    */
@@ -10,7 +10,7 @@ declare namespace Xrm {
     /**
      * The context of the page.
      */
-    context: Xrm.context;
+    context: _XRMNS_.context;
   }
 
   interface context {
@@ -98,7 +98,7 @@ declare namespace Xrm {
   }
 }
 
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
+interface _XRMNS_<T extends _XRMNS_.PageBase<_XRMNS_.AttributeCollectionBase, _XRMNS_.TabCollectionBase, _XRMNS_.ControlCollectionBase>> extends BaseXrm {
   /**
    * The Xrm.Page object model, which contains data about the current page.
    */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface DataModule<T extends AttributeCollectionBase> {
     /**

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface BaseControl {
     /**
      * Display a message near the control to indicate that data isn?t valid. When this method is used on Microsoft Dynamics CRM for tablets a red "X" icon appears next to the control. Tapping on the icon will display the message.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-9-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface Utility {
     /**
      * Displays a dialog box containing an application-defined message.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   /**
    * Interface for the ui of a form.
    */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-9-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface context {
     /**
      * Returns whether Autosave is enabled for the organization.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface SubGridControl<T extends string> extends BaseControl {
     /**
      * Add event handlers to this event to run every time the subgrid refreshes.
@@ -78,7 +78,7 @@ declare namespace Xrm {
     /**
      * Returns an entity reference for the record in the row.
      */
-    getEntityReference(): Xrm.EntityReference<T>;
+    getEntityReference(): _XRMNS_.EntityReference<T>;
 
     /**
      * Returns the id for the record in the row.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-8.2.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-8.2.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
 
     interface Utility {
         /**

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7.1-9-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface context {
     /**
      * Returns the difference between the local time and Coordinated Universal Time (UTC).

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface PageTab<T extends SectionCollectionBase> {
     /**

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-9.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8-9.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   /**
    * Interface for the business process flow on a form.
    */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-.d.ts
@@ -4,7 +4,7 @@
 //Function helper type for a function that can be set to be called by a view column to show an image with a tooltip instead of the ordinary data
 type TooltipFunc = (rowData: string, lcid: LCID) => [WebResourceImage, string];
 
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   const enum ProcessStatus {
     Active = "active",
     Aborted = "aborted",

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-9-.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference 
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
     interface StringControl extends Control<Attribute<string>> {
         /**
          * Use this to add a function as an event handler for the keypress event so that the function is called when you type a character in the specific text field.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-9.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_8.2-9.d.ts
@@ -1,6 +1,6 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   interface Process {
     /**
      * Use this method to get the current status of the process instance

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
 
-declare namespace Xrm {
+declare namespace _XRMNS_ {
     let Device: Device;
     let Encoding: Encoding;
     let Navigation: Navigation;
@@ -612,7 +612,7 @@ declare namespace Xrm {
          * @param file An object describing the file to open.
          * @param openFileOptions Specify whether to open or save the file.
          */
-        openFile(file: Xrm.File, openFileOptions?: OpenFileOptions): void;
+      openFile(file: _XRMNS_.File, openFileOptions?: OpenFileOptions): void;
 
         /**
          * Opens an entity form or a quick create form.
@@ -963,7 +963,7 @@ declare namespace Xrm {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface ExecutionContext<TSource, TArgs> {
-        getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>;
+        getFormContext(): _XRMNS_.PageBase<_XRMNS_.AttributeCollectionBase, _XRMNS_.TabCollectionBase, _XRMNS_.ControlCollectionBase>;
     }
 
     interface SaveOptions {
@@ -1439,10 +1439,10 @@ declare namespace Xrm {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
-    Device: Xrm.Device;
-    Encoding: Xrm.Encoding;
-    Navigation: Xrm.Navigation;
-    //UI: Xrm.UI;
-    WebApi: Xrm.WebApi;
+interface _XRMNS_<T extends _XRMNS_.PageBase<_XRMNS_.AttributeCollectionBase, _XRMNS_.TabCollectionBase, _XRMNS_.ControlCollectionBase>> extends BaseXrm {
+    Device: _XRMNS_.Device;
+    Encoding: _XRMNS_.Encoding;
+    Navigation: _XRMNS_.Navigation;
+    //UI: _XRMNS_.UI;
+    WebApi: _XRMNS_.WebApi;
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
@@ -1,7 +1,7 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
 
-declare namespace Xrm {
+declare namespace _XRMNS_ {
     interface userSettings {
         /**
          * An array of strings that represent the GUID values of each of the security roles that the user is associated with or any teams that the user is associated with.

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -1,7 +1,7 @@
 ﻿// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="..\xrm.d.ts" />
 
-declare namespace Xrm {
+declare namespace _XRMNS_ {
     let App: App;
     let Panel: Panel;
     interface App {

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -1,4 +1,4 @@
-﻿declare namespace Xrm {
+﻿declare namespace _XRMNS_ {
   /**
    * Enum which corresponds to the values of Xrm.Page.ui.getFormType()
    */
@@ -411,7 +411,7 @@
   }
 
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  interface Control<T extends Xrm.Attribute<any>> extends BaseControl {
+  interface Control<T extends _XRMNS_.Attribute<any>> extends BaseControl {
     /**
      * Get the attribute this control is bound to.
      */
@@ -1114,12 +1114,12 @@
     /**
      * Data on the page.
      */
-    data: Xrm.DataModule<T>;
+    data: _XRMNS_.DataModule<T>;
 
     /**
      * UI of the page.
      */
-    ui: Xrm.UiModule<U, V>;
+    ui: _XRMNS_.UiModule<U, V>;
 
     /**
      * Returns string with current page URL.
@@ -1134,28 +1134,28 @@
     /**
      * Generic getAttribute
      */
-    getAttribute(attrName: string): Xrm.Attribute<any> | undefined; //eslint-disable-line @typescript-eslint/no-explicit-any
+    getAttribute(attrName: string): _XRMNS_.Attribute<any> | undefined; //eslint-disable-line @typescript-eslint/no-explicit-any
 
     /**
      * Generic getControl
      */
-    getControl(ctrlName: string): Xrm.AnyControl | undefined;
+    getControl(ctrlName: string): _XRMNS_.AnyControl | undefined;
   }
 }
 
-type BaseXrm = typeof Xrm;
+type BaseXrm = typeof _XRMNS_;
 /**
  * Client-side xRM object model.
  */
 //eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
+interface _XRMNS_<T extends _XRMNS_.PageBase<_XRMNS_.AttributeCollectionBase, _XRMNS_.TabCollectionBase, _XRMNS_.ControlCollectionBase>> extends BaseXrm {
   /**
    * Various utility functions can be found here.
    */
-  Utility: Xrm.Utility;
+  Utility: _XRMNS_.Utility;
 }
 
-declare namespace Xrm {
+declare namespace _XRMNS_ {
   let Utility: Utility;
 
   /**

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
@@ -9,7 +9,7 @@ open GenerationMain
 
 type XrmDefinitelyTyped private () = 
 
-  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?clientId, ?returnUrl, ?clientSecret, ?connectionString, ?outDir, ?jsLib, ?tsLib, ?entities, ?solutions, ?crmVersion, ?useDeprecated, ?skipForms, ?oneFile, ?restNs, ?webNs, ?viewNs, ?formIntersects, ?viewintersects, ?labelMapping, ?generateMapping, ?skipInactiveForms) = 
+  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?clientId, ?returnUrl, ?clientSecret, ?connectionString, ?outDir, ?jsLib, ?tsLib, ?entities, ?solutions, ?crmVersion, ?useDeprecated, ?skipForms, ?oneFile, ?restNs, ?webNs, ?viewNs, ?formIntersects, ?viewintersects, ?labelMapping, ?generateMapping, ?skipInactiveForms, ?xrmNs) = 
     let xrmAuth = 
       { XrmAuthentication.url = Uri(url)
         method = method
@@ -43,7 +43,7 @@ type XrmDefinitelyTyped private () =
         viewIntersects = viewintersects
         labelMapping = labelMapping
         generateMappings = generateMapping ?| false
-        xrmNs = "Xrm"
+        xrmNs = xrmNs ?| "Xrm"
        }
     
     XrmDefinitelyTyped.GenerateFromCrm(xrmAuth, rSettings, gSettings)
@@ -53,7 +53,7 @@ type XrmDefinitelyTyped private () =
     #if !DEBUG 
     try
     #endif 
-      
+
       retrieveRawState xrmAuth rSettings
       |> generateFromRaw gSettings
       printfn "\nSuccessfully generated all TypeScript declaration files."

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
@@ -43,6 +43,7 @@ type XrmDefinitelyTyped private () =
         viewIntersects = viewintersects
         labelMapping = labelMapping
         generateMappings = generateMapping ?| false
+        xrmNs = "Xrm"
        }
     
     XrmDefinitelyTyped.GenerateFromCrm(xrmAuth, rSettings, gSettings)


### PR DESCRIPTION
Allow for overriding the Xrm namespace, providing a custom one if needed.

Instead of wrapping Xrm in another namespace level (which would require an additional namespace declaration in both xrm.d.ts AND all version-specific files, simply renaming the namespace keeps the needed changes down.

Still not sure it works. It looked as if VS was acting up post generation, but I would prefer a re-review.