### PR TITLE
Add getContentWindow method in ExternalControl( Webresource and IFrame)

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -1429,6 +1429,12 @@ declare namespace Xrm {
     interface BaseControl {
         addNotification(notification: AddNotificationObject): void;
     }
+    interface ExternalControl {
+        /**
+         * Returns the content window that represents an IFRAME or web resource.
+         */
+        getContentWindow(): Promise<any>;
+    }
 
     interface NavigationBehaviorObject {
         allowCreateNew(): boolean


### PR DESCRIPTION
This method extends the ExternalControl which is inherited in WebresourceControl and IframeControl. On success, returns a promise that contains a content window instance representing an IFRAME or web resource.
More info : https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getcontentwindow