### PR TITLE
Modified getControl, getAttribute and get to return the basic type instead of undefined

### DIFF
--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
@@ -179,7 +179,7 @@ let getAttributeFuncs (attributes: XrmFormAttribute list) =
   let defaultFunc =
     Function.Create("getAttribute", 
       [ Variable.Create("attributeName", TsType.String) ], 
-      TsType.Undefined )
+      TsType.Custom("Xrm.Attribute<any>") )
   
   let delegateFunc =
       Function.Create("getAttribute",
@@ -208,7 +208,7 @@ let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version)=
   let defaultFunc =
     Function.Create("getControl", 
       [ Variable.Create("controlName", TsType.String) ], 
-      TsType.Undefined)
+      TsType.Custom("Xrm.BaseControl"))
   
   let delegateFunc =
     Function.Create("getControl",

--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
@@ -60,7 +60,7 @@ let getControlInterface cType aType canBeNull =
 /// Default collection functions which also use the "get" function name.
 let defaultCollectionFuncs defaultType = 
   [ Function.Create("get", 
-      [ Variable.Create("name", TsType.String) ], TsType.Undefined)
+      [ Variable.Create("name", TsType.String) ], TsType.Custom defaultType)
 
     Function.Create("get", [], TsType.Array (TsType.Custom defaultType))
     Function.Create("get", 

--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateFormDts.fs
@@ -208,7 +208,7 @@ let getControlFuncs (controls: XrmFormControl list) (crmVersion: Version)=
   let defaultFunc =
     Function.Create("getControl", 
       [ Variable.Create("controlName", TsType.String) ], 
-      TsType.Custom("Xrm.BaseControl"))
+      TsType.Custom("Xrm.AnyControl"))
   
   let delegateFunc =
     Function.Create("getControl",


### PR DESCRIPTION
My team start adopting strictest for TypeScript. https://www.npmjs.com/package/@tsconfig/strictest
It's doesn't like undefined alot as return type.

The getAttribute and getControl have been changed to return the basic type matching the method.