### PR TITLE
Typings for custom controls no longer default to BaseControl.

### DIFF
--- a/src/XrmDefinitelyTyped/Interpretation/InterpretBpfJson.fs
+++ b/src/XrmDefinitelyTyped/Interpretation/InterpretBpfJson.fs
@@ -70,7 +70,7 @@ let rec analyzeEntity (data:List<InnerData>) (fields:ControlField list) : Contro
       match box d.controlId with
       | null -> fields
       | _ ->
-        let controlClass = getControlClass d.controlId d.classId
+        let controlClass = getControlClass d.controlId d.classId String.Empty Map.empty // Empty string and map must be replaced to generate proper typings for controls in BPFs
         ( d.controlId, 
           d.dataFieldName, 
           controlClass,


### PR DESCRIPTION
Typings for custom controls will be generated based on the controltype they replace instead of alle defaulting to `BaseControl`.
#274: This includes typing EditableGrid and Power Apps Grid as grids.