### PR TITLE
XrmQuery default API version based on CRM Version

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1379,7 +1379,7 @@ namespace XQW {
    * @internal
    */
   export let ApiUrl: string | null = null;
-  const DefaultApiVersion = Xrm.Utility.getGlobalContext().getVersion().split('.').slice(0, 2).join('.');
+  const DefaultApiVersion = Xrm.Utility.getGlobalContext().getVersion().split(".").slice(0, 2).join(".");
 
   export function getDefaultUrl(v: string) {
     return getClientUrl() + `/api/data/v${v}/`;

--- a/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
+++ b/src/XrmDefinitelyTyped/Resources/dg.xrmquery.web.ts
@@ -1379,7 +1379,7 @@ namespace XQW {
    * @internal
    */
   export let ApiUrl: string | null = null;
-  const DefaultApiVersion = "9.2";
+  const DefaultApiVersion = Xrm.Utility.getGlobalContext().getVersion().split('.').slice(0, 2).join('.');
 
   export function getDefaultUrl(v: string) {
     return getClientUrl() + `/api/data/v${v}/`;


### PR DESCRIPTION
Related to issue #245 

Changed XrmQuery default API version to be based on CRM Version of the model driven app instead of being hardcoded to 9.2 in the TS "sourcefile" for the XrmQuery JS files

The possible solution i came up with was to replace
```typescript
const DefaultApiVersion = "9.2";
```
with
```typescript
const DefaultApiVersion = Xrm.Utility.getGlobalContext().getVersion().split('.').slice(0, 2).join('.');
```

In ```\src\XrmDefinitelyTyped\Resources\dg.xrmquery.web.ts``` which the xrmQuery files are generated from. In this way the default api version used is decided by the CRM version of the model driven app where the code is run.

Are there any issues with this solution?