### PR TITLE
fix Xrm.Navigation.openFile has inncorect type for openFileOptions

### DIFF
--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -246,7 +246,18 @@ declare namespace Xrm {
         message?: string;
     }
 
-    const enum OpenFileOptions {
+    /**
+     * An object describing whether to open or save the file
+     */
+    interface OpenFileOptions {
+        /**
+         * If you do not specify this parameter, by default 1 (open) is passed.
+         * This parameter is only supported on Unified Interface
+         */
+        openMode?: OpenFileOptionsOpenMode;
+    }
+
+    const enum OpenFileOptionsOpenMode {
         Open = 1,
         Save = 2,
     }


### PR DESCRIPTION
parameter `openFileOptions` must have property `openMode` (and not directly enum value)

docs: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/xrm-navigation/openfile

fixes #302