### PR TITLE
Do not append 1 to field name in select type.

### DIFF
--- a/src/XrmDefinitelyTyped/CreateTypeScript/CreateWebEntities.fs
+++ b/src/XrmDefinitelyTyped/CreateTypeScript/CreateWebEntities.fs
@@ -67,16 +67,6 @@ let assignUniqueNames =
   >> List.concat
 //  >> sortByName
 
-// generates typings for the case where fieldname is the same as the entityname.
-let fixSameNameAttribute (entityLogicalname: string) (vars: Variable list) =
-  vars
-    |> List.fold (fun current var ->
-        if (var.name <> entityLogicalname) then var :: current else
-            match (List.contains (var.name + "1") (List.map (fun (v:Variable) -> v.name) vars)) with
-            | true -> current
-            | false -> Variable.Create(var.name + "1") :: current 
-    ) List.empty             
-
 let concatDistinctSort = 
   List.concat >> List.distinctBy (fun (x: Variable) -> x.name) >> sortByName
 
@@ -310,7 +300,7 @@ let getEntityInterfaceLines ns e =
       { entityInterfaces.create with vars = e.allRelationships |> List.choose (getBindVariables true false attrMap) |> assignUniqueNames |> sortByName }
       { entityInterfaces.update with vars = e.allRelationships |> List.choose (getBindVariables false true attrMap) |> assignUniqueNames |> sortByName }
 
-      { entityInterfaces.select with vars = e.attributes |> List.map (getSelectVariable entityInterfaces.select) |> fixSameNameAttribute (e.logicalName) |> assignUniqueNames |> sortByName } 
+      { entityInterfaces.select with vars = e.attributes |> List.map (getSelectVariable entityInterfaces.select) |> assignUniqueNames |> sortByName } 
       { entityInterfaces.filter with vars = e.attributes |> List.map getFilterVariable |> assignUniqueNames |> sortByName }
       { entityInterfaces.expand with vars = e.availableRelationships |> List.map (getExpandVariable entityInterfaces.expand) |> CreateCommon.mergeOwnerExpand webExpand |> assignUniqueNames |> sortByName }
 

--- a/test/src/tests/XrmQuery/web/result-type/retrieve.ts
+++ b/test/src/tests/XrmQuery/web/result-type/retrieve.ts
@@ -6,9 +6,11 @@ import { suite, test, slow, timeout, skip, only } from "@testdeck/mocha";
 class Web_Retrieve_ResultTypeCheck {
 
     contactId: string;
+    responseId: string;
 
     before() {
         this.contactId = "CONTACT_ID";
+        this.responseId = "RESPONSE_ID";
     }
 
     @test
@@ -39,4 +41,10 @@ class Web_Retrieve_ResultTypeCheck {
             .execute(x => x.birthdate_formatted)
     }
 
+    @test
+    "select, attribute name matches entity name"() {
+        XrmQuery.retrieve(x => x.dg_responses, this.responseId)
+            .select(x => [x.dg_response])
+            .execute(x => x.dg_response)
+    }
 }

--- a/test/src/tests/XrmQuery/web/result-type/retrieveMultiple.ts
+++ b/test/src/tests/XrmQuery/web/result-type/retrieveMultiple.ts
@@ -34,4 +34,11 @@ class Web_RetrieveMultiple_ResultTypeCheck {
             .execute(x => x[0].birthdate_formatted)
     }
 
+    @test
+    "select, attribute name matches entity name"() {
+        XrmQuery.retrieveMultiple(x => x.dg_responses)
+            .select(x => [x.dg_response])
+            .execute(x => x[0].dg_response)
+    }
+
 }


### PR DESCRIPTION
This used to be required, but does not appear to be any longer, and made it impossible to retrieve those fields.

This fixes #40