### PR TITLE
Add support for quickforms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
-### 6.6.0 - June 18 2024
-* Fix types related to QuickForms and form.ui.quickForms (@mkholt)
+### 6.6.0 - June 19 2024
+* Fix types related to QuickViewForms and form.ui.QuickViewForms (@mkholt)
 
 ### 6.5.0 - May 8 2024
 * Fix Xrm.Navigation.openFile has inncorect type for openFileOptions (@matejskubic)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 # Release Notes
+### 6.6.0 - June 18 2024
+* Fix types related to QuickForms and form.ui.quickForms (@mkholt)
+
 ### 6.5.0 - May 8 2024
 * Fix Xrm.Navigation.openFile has inncorect type for openFileOptions (@matejskubic)
 * Do not append 1 to field name in select type (@mkholt)

--- a/src/XrmDefinitelyTyped/AssemblyInfo.fs
+++ b/src/XrmDefinitelyTyped/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Tool to generate TypeScript declaration files for MS Dynamics 365/CRM client-side coding.")>]
 [<assembly: AssemblyCompanyAttribute("Delegate A/S")>]
 [<assembly: AssemblyCopyrightAttribute("Copyright (c) Delegate A/S 2017")>]
-[<assembly: AssemblyVersionAttribute("6.5.0")>]
-[<assembly: AssemblyFileVersionAttribute("6.5.0")>]
+[<assembly: AssemblyVersionAttribute("6.6.0")>]
+[<assembly: AssemblyFileVersionAttribute("6.6.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -17,5 +17,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "Tool to generate TypeScript declaration files for MS Dynamics 365/CRM client-side coding."
     let [<Literal>] AssemblyCompany = "Delegate A/S"
     let [<Literal>] AssemblyCopyright = "Copyright (c) Delegate A/S 2017"
-    let [<Literal>] AssemblyVersion = "6.5.0"
-    let [<Literal>] AssemblyFileVersion = "6.5.0"
+    let [<Literal>] AssemblyVersion = "6.6.0"
+    let [<Literal>] AssemblyFileVersion = "6.6.0"

--- a/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
+++ b/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
@@ -264,12 +264,11 @@ let generateFormDefs state crmVersion generateMappings =
 
   let formMap =
     state.forms
-    |> Array.map (fun (form: XrmForm) ->
+    |> Array.choose (fun (form: XrmForm) ->
       match form.guid with 
       | Some formId -> Some (formId, form)
       | None -> None
     )
-    |> Array.choose id
     |> Map.ofArray
   
   let defs = 

--- a/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
+++ b/src/XrmDefinitelyTyped/Generation/FileGeneration.fs
@@ -261,6 +261,16 @@ let generateWebEntityDefs ns state =
 let generateFormDefs state crmVersion generateMappings = 
   printf "Generation Form definitions..."
   let getFormType xrmForm = xrmForm.formType ?|> sprintf "/%s" ?| ""
+
+  let formMap =
+    state.forms
+    |> Array.map (fun (form: XrmForm) ->
+      match form.guid with 
+      | Some formId -> Some (formId, form)
+      | None -> None
+    )
+    |> Array.choose id
+    |> Map.ofArray
   
   let defs = 
     state.forms
@@ -275,7 +285,7 @@ let generateFormDefs state crmVersion generateMappings =
     |> Array.filter (fun (form: XrmForm) -> form.formType.IsNone || (form.formType.IsSome && form.formType.Value <> "Card" && form.formType.Value <> "InteractionCentricDashboard" && form.formType.Value <> "TaskFlowForm"))
     |> Array.Parallel.map (fun xrmForm -> 
          let path = sprintf "%s/Form/%s%s" state.outputDir xrmForm.entityName (getFormType xrmForm)
-         let lines = getFormDts xrmForm crmVersion generateMappings
+         let lines = getFormDts xrmForm formMap crmVersion generateMappings
          sprintf "%s/%s.d.ts" path xrmForm.name, lines)
 
   printfn "Done!"

--- a/src/XrmDefinitelyTyped/Generation/Setup.fs
+++ b/src/XrmDefinitelyTyped/Generation/Setup.fs
@@ -18,8 +18,8 @@ let intersectMappedSets a b = Map.ofSeq (seq {
 
 // Reduces a list of quadruple sets to a single quadruple set
 let intersectFormQuads =
-  Seq.reduce (fun (d1, a1, c1, t1) (d2, a2, c2, t2) ->
-    Set.union d1 d2, Set.intersect a1 a2, Set.intersect c1 c2, intersectMappedSets t1 t2)
+  Seq.reduce (fun (d1, a1, c1, q1, t1) (d2, a2, c2, q2, t2) ->
+    Set.union d1 d2, Set.intersect a1 a2, Set.intersect c1 c2, Set.intersect q1 q2, intersectMappedSets t1 t2)
 
 let intersectContentByGuid typ (dict: IDictionary<Guid, 'a>) ((name, guids): Intersect) contentMap reduce =
   guids 
@@ -39,6 +39,7 @@ let intersectFormContentByGuid (formDict: IDictionary<Guid, XrmForm>) intersect 
       f.entityDependencies |> Set.ofSeq,  
       f.attributes |> Set.ofList, 
       f.controls |> Set.ofList, 
+      f.quickForms |> Set.ofList,
       f.tabs |> Seq.map (fun (name, iname, sections) -> (name, iname), sections |> Set.ofList) |> Map.ofSeq)
 
   intersectContentByGuid "Form" formDict intersect contentMap intersectFormQuads
@@ -63,7 +64,7 @@ let intersect (dict: IDictionary<Guid, 'a>) instersectContentByGuids mapContent 
 // Intersect forms based on argument
 let intersectForms formDict formsToIntersect =
   let contentMap =
-    (fun (name, (deps, a, c, t)) -> 
+    (fun (name, (deps, a, c, q, t)) -> 
     { XrmForm.name = name
       entityName = "_special"
       guid = None
@@ -71,6 +72,7 @@ let intersectForms formDict formsToIntersect =
       formType = None
       attributes = a |> Set.toList
       controls = c |> Set.toList
+      quickForms = q |> Seq.toList
       tabs = t |> Map.toList |> List.map (fun ((k1, k2), v) -> k1, k2, v |> Set.toList)
     })
 

--- a/src/XrmDefinitelyTyped/Generation/Setup.fs
+++ b/src/XrmDefinitelyTyped/Generation/Setup.fs
@@ -39,7 +39,7 @@ let intersectFormContentByGuid (formDict: IDictionary<Guid, XrmForm>) intersect 
       f.entityDependencies |> Set.ofSeq,  
       f.attributes |> Set.ofList, 
       f.controls |> Set.ofList, 
-      f.quickForms |> Set.ofList,
+      f.quickViewForms |> Set.ofList,
       f.tabs |> Seq.map (fun (name, iname, sections) -> (name, iname), sections |> Set.ofList) |> Map.ofSeq)
 
   intersectContentByGuid "Form" formDict intersect contentMap intersectFormQuads
@@ -72,7 +72,7 @@ let intersectForms formDict formsToIntersect =
       formType = None
       attributes = a |> Set.toList
       controls = c |> Set.toList
-      quickForms = q |> Seq.toList
+      quickViewForms = q |> Seq.toList
       tabs = t |> Map.toList |> List.map (fun ((k1, k2), v) -> k1, k2, v |> Set.toList)
     })
 

--- a/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
+++ b/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
@@ -99,11 +99,12 @@ type FormType =
   | AppointmentBookBackup = 102
 
 type CanBeNull = bool
-type QuickFormReference = string * System.Guid
+type QuickViewReference = string * System.Guid
+
 type XrmFormAttribute = string * AttributeType * CanBeNull
 type XrmFormControl = string * XrmFormAttribute option * ControlType * bool * CanBeNull
 type XrmFormTab = string * string * string list
-type XrmFormQuickForm = string * QuickFormReference
+type XrmFormQuickViewForm = string * QuickViewReference
   
 type ControlClassId =
   | CheckBox | DateTime | Decimal | Duration | EmailAddress | EmailBody 
@@ -125,10 +126,8 @@ type XrmForm = {
   name: string
   attributes: XrmFormAttribute list
   controls: XrmFormControl list
-  quickForms: XrmFormQuickForm list
+  quickViewForms: XrmFormQuickViewForm list
   tabs: XrmFormTab list
- 
-  
 }
 
 

--- a/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
+++ b/src/XrmDefinitelyTyped/IntermediateRepresentation.fs
@@ -99,9 +99,11 @@ type FormType =
   | AppointmentBookBackup = 102
 
 type CanBeNull = bool
+type QuickFormReference = string * System.Guid
 type XrmFormAttribute = string * AttributeType * CanBeNull
-type XrmFormControl = string * AttributeType option * ControlType * bool * CanBeNull
+type XrmFormControl = string * XrmFormAttribute option * ControlType * bool * CanBeNull
 type XrmFormTab = string * string * string list
+type XrmFormQuickForm = string * QuickFormReference
   
 type ControlClassId =
   | CheckBox | DateTime | Decimal | Duration | EmailAddress | EmailBody 
@@ -112,7 +114,7 @@ type ControlClassId =
   | Other
   with override x.ToString() = x.GetType().Name
 
-type ControlField = string * string * ControlClassId * CanBeNull * bool * string option
+type ControlField = string * string * ControlClassId * CanBeNull * bool * string option * string list option
 
 
 type XrmForm = {
@@ -123,6 +125,7 @@ type XrmForm = {
   name: string
   attributes: XrmFormAttribute list
   controls: XrmFormControl list
+  quickForms: XrmFormQuickForm list
   tabs: XrmFormTab list
  
   

--- a/src/XrmDefinitelyTyped/Interpretation/InterpretBpfJson.fs
+++ b/src/XrmDefinitelyTyped/Interpretation/InterpretBpfJson.fs
@@ -79,6 +79,7 @@ let rec analyzeEntity (data:List<InnerData>) (fields:ControlField list) : Contro
           match box d.entity, controlClass with
           | e, Lookup when e <> null -> Some (sprintf "\"%s\"" d.entity.entityName)
           | _, _ -> None
+          , None
         ) :: fields
     | _ -> fields
   ) |> List.concat
@@ -107,6 +108,6 @@ let interpretBpfs (workflows:Entity[]): Map<string,ControlField list> =
     lname, 
     x |> Array.map snd 
     |> List.concat 
-    |> List.filter (fun (_, datafieldname,_,_,_,_) -> datafieldname <> String.Empty)
-    |> List.map (fun (id, datafieldname, controlClass, canBeNull, _, tes) -> sprintf "header_process_%s" datafieldname, datafieldname,  controlClass, canBeNull, true, tes))
+    |> List.filter (fun (_, datafieldname,_,_,_,_,_) -> datafieldname <> String.Empty)
+    |> List.map (fun (id, datafieldname, controlClass, canBeNull, _, tes, qfs) -> sprintf "header_process_%s" datafieldname, datafieldname,  controlClass, canBeNull, true, tes, qfs))
     |> Map.ofArray

--- a/src/XrmDefinitelyTyped/Interpretation/InterpretFormXml.fs
+++ b/src/XrmDefinitelyTyped/Interpretation/InterpretFormXml.fs
@@ -245,9 +245,9 @@ let getCompositeFields : ControlField list -> ControlField list =
     | _ -> None
   ) >> List.concat
 
-let getQuickFormControls : ControlField list -> XrmFormQuickForm list =
-  List.choose (fun (controlId, _, _, _, _, _, quickForms) ->
-    match quickForms with
+let getQuickViewFormControls : ControlField list -> XrmFormQuickViewForm list =
+  List.choose (fun (controlId, _, _, _, _, _, quickViewForms) ->
+    match quickViewForms with
     | Some qf ->
       let qfHead = qf |> List.head
       let qfIds = XElement.Parse qfHead
@@ -320,7 +320,7 @@ let interpretFormXml (enums:Map<string,TsType>) (bpfFields: ControlField list op
           |> Seq.map (fun e -> e.Value)
           |> Seq.toList
 
-      let quickForms =
+      let quickViewForms =
         let parms = c.Descendants(XName.Get("parameters"))
         if Seq.isEmpty parms then None
         else
@@ -342,9 +342,9 @@ let interpretFormXml (enums:Map<string,TsType>) (bpfFields: ControlField list op
       if(targetEntities.Length > 0) then
         let tes =
           Seq.fold(fun acc e -> sprintf "%s | \"%s\"" acc e) (sprintf "\"%s\"" targetEntities.Head) targetEntities.Tail
-        id, datafieldname, controlClass, canBeNull, false, Some tes, quickForms
+        id, datafieldname, controlClass, canBeNull, false, Some tes, quickViewForms
       else
-        id, datafieldname, controlClass, canBeNull, false, None, quickForms
+        id, datafieldname, controlClass, canBeNull, false, None, quickViewForms
     )
     |> List.ofSeq
 
@@ -372,7 +372,7 @@ let interpretFormXml (enums:Map<string,TsType>) (bpfFields: ControlField list op
       |> renameControls
       |> List.sortBy (fun (name, _, _, _,_) -> name)
 
-    quickForms = getQuickFormControls controlFields
+    quickViewForms = getQuickViewFormControls controlFields
 
     tabs = tabs
   }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
@@ -6,7 +6,7 @@ declare namespace Xrm {
    * Interface for the base of an Xrm.Page
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface PageBase<T extends AttributeCollectionBase, U extends TabCollectionBase, V extends ControlCollectionBase> {
+  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
     /**
      * The context of the page.
      */
@@ -98,7 +98,7 @@ declare namespace Xrm {
   }
 }
 
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
   /**
    * The Xrm.Page object model, which contains data about the current page.
    */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_-9-.d.ts
@@ -6,7 +6,7 @@ declare namespace Xrm {
    * Interface for the base of an Xrm.Page
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
     /**
      * The context of the page.
      */
@@ -98,7 +98,7 @@ declare namespace Xrm {
   }
 }
 
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickViewFormCollectionBase>> extends BaseXrm {
   /**
    * The Xrm.Page object model, which contains data about the current page.
    */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
@@ -64,7 +64,7 @@ declare namespace Xrm {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface UiModule<T extends TabCollectionBase, U extends ControlCollectionBase> {
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
     /**
      * Use this method to remove form level notifications.
      *

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_6-.d.ts
@@ -64,7 +64,7 @@ declare namespace Xrm {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
     /**
      * Use this method to remove form level notifications.
      *

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
@@ -5,7 +5,7 @@ declare namespace Xrm {
    * Interface for the ui of a form.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
     /**
      * Access UI controls for the business process flow on the form.
      */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_7-.d.ts
@@ -5,7 +5,7 @@ declare namespace Xrm {
    * Interface for the ui of a form.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface UiModule<T extends TabCollectionBase, U extends ControlCollectionBase> {
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
     /**
      * Access UI controls for the business process flow on the form.
      */

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -997,7 +997,7 @@ declare namespace Xrm {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface ExecutionContext<TSource, TArgs> {
-        getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>;
+        getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickViewFormCollectionBase>;
     }
 
     interface SaveOptions {
@@ -1099,7 +1099,7 @@ declare namespace Xrm {
      * Interface for the ui of a form.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
         /**
          * Adds a function to be called on the form OnLoad event.
          * @param myFunction The function to be executed on the form OnLoad event. The function will be added to the bottom of the event handler pipeline.
@@ -1479,7 +1479,7 @@ declare namespace Xrm {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickViewFormCollectionBase>> extends BaseXrm {
     Device: Xrm.Device;
     Encoding: Xrm.Encoding;
     Navigation: Xrm.Navigation;

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-.d.ts
@@ -997,7 +997,7 @@ declare namespace Xrm {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface ExecutionContext<TSource, TArgs> {
-        getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>;
+        getFormContext(): Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>;
     }
 
     interface SaveOptions {
@@ -1099,7 +1099,7 @@ declare namespace Xrm {
      * Interface for the ui of a form.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface UiModule<T extends TabCollectionBase, U extends ControlCollectionBase> {
+    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
         /**
          * Adds a function to be called on the form OnLoad event.
          * @param myFunction The function to be executed on the form OnLoad event. The function will be added to the bottom of the event handler pipeline.
@@ -1479,7 +1479,7 @@ declare namespace Xrm {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
     Device: Xrm.Device;
     Encoding: Xrm.Encoding;
     Navigation: Xrm.Navigation;

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
@@ -10,5 +10,5 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-explicit-any
-    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, any> { }
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickViewFormCollectionBase>, any> { }
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9-9.1-.d.ts
@@ -10,5 +10,5 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-explicit-any
-    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, any> { }
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, any> { }
 }

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -234,7 +234,7 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, LoadEventArgs> {}
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickViewFormCollectionBase>, LoadEventArgs> {}
 
     interface LookupTagValue extends Lookup {
         /**
@@ -295,7 +295,7 @@ declare namespace Xrm {
      * Interface for the ui of a form.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
         /**
          * Method to cause the ribbon to re-evaluate data that controls what is displayed in it.
          */
@@ -459,7 +459,7 @@ declare namespace Xrm {
         setVisible(visibility: boolean): void;
     }
     
-    interface QuickForm<T extends TabCollectionBase, C extends ControlCollectionBase> extends PageBase<AttributeCollectionBase, T, C, QuickFormCollectionBase> {
+    interface QuickViewForm<T extends TabCollectionBase, C extends ControlCollectionBase> extends PageBase<AttributeCollectionBase, T, C, QuickViewFormCollectionBase> {
         /**
          * Returns a string value that categorizes quick view controls.
          * For a quick view control, the method returns "quickform".
@@ -756,7 +756,7 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface OnRecordSelectEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, undefined> {
+    interface OnRecordSelectEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickViewFormCollectionBase>, undefined> {
     }
 
     const enum WebApiOperationType {

--- a/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/Extensions/xrm_ext_9.1-.d.ts
@@ -234,7 +234,7 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, LoadEventArgs> {}
+    interface OnLoadEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, LoadEventArgs> {}
 
     interface LookupTagValue extends Lookup {
         /**
@@ -295,7 +295,7 @@ declare namespace Xrm {
      * Interface for the ui of a form.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface UiModule<T extends TabCollectionBase, U extends ControlCollectionBase> {
+    interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
         /**
          * Method to cause the ribbon to re-evaluate data that controls what is displayed in it.
          */
@@ -326,7 +326,7 @@ declare namespace Xrm {
          * You can retrieve a quick view control in the quickForms collection by using the get method by specifying
          * either the index value (integer) or name (string) of the quick view control as the argument:
          */
-        quickForms: QuickForms;
+        quickForms: Q;
 
         /**
          * A tab is a group of sections on a page. It contains properties and methods to manipulate tabs
@@ -458,16 +458,8 @@ declare namespace Xrm {
          */
         setVisible(visibility: boolean): void;
     }
-
-    interface QuickForms {
-        /**
-         * Gets the control on a form.
-         * @param arg Optional. You can access a single control in the constituent controls collection by passing an
-         * argument as either the name or the index value of the constituent control in a quick view control.
-         * For example: quickViewControl.getControl("firstname") or quickViewControl.getControl(0)
-         * Returns an Object or Object collection
-         */
-        getControl(arg?: string): any //eslint-disable-line @typescript-eslint/no-explicit-any
+    
+    interface QuickForm<T extends TabCollectionBase, C extends ControlCollectionBase> extends PageBase<AttributeCollectionBase, T, C, QuickFormCollectionBase> {
         /**
          * Returns a string value that categorizes quick view controls.
          * For a quick view control, the method returns "quickform".
@@ -764,7 +756,7 @@ declare namespace Xrm {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface OnRecordSelectEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase>, undefined> {
+    interface OnRecordSelectEventContext extends ExecutionContext<UiModule<TabCollectionBase, ControlCollectionBase, QuickFormCollectionBase>, undefined> {
     }
 
     const enum WebApiOperationType {

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -146,7 +146,7 @@
   /**
    * A collection of tabs.
    */
-  interface TabCollection extends Collection<PageTab<SectionCollection>> {} //eslint-disable-line @typescript-eslint/no-empty-interface
+  interface TabCollection extends Collection<PageTab<SectionCollection>> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
   /**
    * A collection of attributes.
@@ -166,7 +166,20 @@
   /**
    * A collection of tabs.
    */
-  interface TabCollectionBase extends CollectionBase<PageTab<SectionCollectionBase>> {} //eslint-disable-line @typescript-eslint/no-empty-interface
+  interface TabCollectionBase extends CollectionBase<PageTab<SectionCollectionBase>> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+
+  /**
+   * A collection of quickforms.
+   */
+  interface QuickFormCollection extends Collection<QuickFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+
+  /**
+   * A collection of quickforms
+  */
+  interface QuickFormCollectionBase extends CollectionBase<QuickFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+
+  interface QuickForm<T extends TabCollectionBase, C extends ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
+  interface QuickFormBase extends QuickForm<TabCollectionBase, ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
   type AttributeType = "boolean" | "datetime" | "decimal" | "double" | "integer" | "lookup" | "memo" | "money" | "optionset" | "string" | "multiselectoptionset";
 
@@ -553,7 +566,7 @@
    */
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   type AnyControl = BaseControl & Partial<Control<any> & WebResourceControl & IFrameControl & LookupControl<string> & SubGridControl<string> & DateControl & OptionSetControl<any>>;
-
+  
   const enum ViewTypeNumber {
     SavedQuery = 1039,
     UserQuery = 4230,
@@ -926,7 +939,7 @@
     /**
      * Returns the Xrm.Page.ui object.
      */
-    getParent(): UiModule<Collection<PageTab<Collection<PageSection>>>, Collection<BaseControl>>;
+    getParent(): UiModule<Collection<PageTab<Collection<PageSection>>>, Collection<BaseControl>, Collection<QuickFormBase>>;
 
     /**
      * Returns the tab label.
@@ -961,7 +974,8 @@
   /**
    * Interface for the ui of a form.
    */
-  interface UiModule<T extends TabCollectionBase, U extends ControlCollectionBase> {
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
     /**
      * Collection of tabs on the page.
      */
@@ -970,7 +984,7 @@
     /**
      * Collection of controls on the page.
      */
-    controls: U;
+    controls: C;
 
     /**
      * Navigation for the page.
@@ -1110,22 +1124,22 @@
   /**
    * Interface for the base of an Xrm.Page
    */
-  interface PageBase<T extends AttributeCollectionBase, U extends TabCollectionBase, V extends ControlCollectionBase> {
+  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
     /**
      * Data on the page.
      */
-    data: Xrm.DataModule<T>;
+    data: Xrm.DataModule<A>;
 
     /**
      * UI of the page.
      */
-    ui: Xrm.UiModule<U, V>;
+    ui: Xrm.UiModule<T, C, Q>;
 
     /**
      * Returns string with current page URL.
      */
     getUrl(): string;
-  }
+    }
 
   /**
    * Interface for a generic Xrm.Page
@@ -1148,7 +1162,7 @@ type BaseXrm = typeof Xrm;
  * Client-side xRM object model.
  */
 //eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
   /**
    * Various utility functions can be found here.
    */

--- a/src/XrmDefinitelyTyped/Resources/xrm.d.ts
+++ b/src/XrmDefinitelyTyped/Resources/xrm.d.ts
@@ -169,17 +169,17 @@
   interface TabCollectionBase extends CollectionBase<PageTab<SectionCollectionBase>> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
   /**
-   * A collection of quickforms.
+   * A collection of QuickViewForms.
    */
-  interface QuickFormCollection extends Collection<QuickFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+  interface QuickViewFormCollection extends Collection<QuickViewFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
   /**
-   * A collection of quickforms
+   * A collection of QuickViewForms
   */
-  interface QuickFormCollectionBase extends CollectionBase<QuickFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+  interface QuickViewFormCollectionBase extends CollectionBase<QuickViewFormBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
-  interface QuickForm<T extends TabCollectionBase, C extends ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
-  interface QuickFormBase extends QuickForm<TabCollectionBase, ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
+  interface QuickViewForm<T extends TabCollectionBase, C extends ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
+  interface QuickViewFormBase extends QuickViewForm<TabCollectionBase, ControlCollectionBase> { } //eslint-disable-line @typescript-eslint/no-empty-interface
 
   type AttributeType = "boolean" | "datetime" | "decimal" | "double" | "integer" | "lookup" | "memo" | "money" | "optionset" | "string" | "multiselectoptionset";
 
@@ -939,7 +939,7 @@
     /**
      * Returns the Xrm.Page.ui object.
      */
-    getParent(): UiModule<Collection<PageTab<Collection<PageSection>>>, Collection<BaseControl>, Collection<QuickFormBase>>;
+    getParent(): UiModule<Collection<PageTab<Collection<PageSection>>>, Collection<BaseControl>, Collection<QuickViewFormBase>>;
 
     /**
      * Returns the tab label.
@@ -975,7 +975,7 @@
    * Interface for the ui of a form.
    */
   //eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+  interface UiModule<T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
     /**
      * Collection of tabs on the page.
      */
@@ -1124,7 +1124,7 @@
   /**
    * Interface for the base of an Xrm.Page
    */
-  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickFormCollectionBase = QuickFormCollectionBase> {
+  interface PageBase<A extends AttributeCollectionBase, T extends TabCollectionBase, C extends ControlCollectionBase, Q extends QuickViewFormCollectionBase = QuickViewFormCollectionBase> {
     /**
      * Data on the page.
      */
@@ -1162,7 +1162,7 @@ type BaseXrm = typeof Xrm;
  * Client-side xRM object model.
  */
 //eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickFormCollectionBase>> extends BaseXrm {
+interface Xrm<T extends Xrm.PageBase<Xrm.AttributeCollectionBase, Xrm.TabCollectionBase, Xrm.ControlCollectionBase, Xrm.QuickViewFormCollectionBase>> extends BaseXrm {
   /**
    * Various utility functions can be found here.
    */

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
@@ -78,7 +78,7 @@ type XrmDefinitelyTyped private () =
 
       retrieveRawState xrmAuth rSettings
       |> fun state -> serializer.WriteObject(stream, state)
-      printfn "\nSuccessfully saved retrieved data to file."
+      printfn "\nSuccessfully saved retrieved data to file %s." (Path.GetFullPath filePath)
 
     #if !DEBUG
     with ex -> getFirstExceptionMessage ex |> failwithf "\nUnable to generate data file: %s"

--- a/test/.vscode/tasks.json
+++ b/test/.vscode/tasks.json
@@ -1,9 +1,29 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "tsc",
-    "isShellCommand": true,
-    "args": ["-p", ".", "-w"],
-    "showOutput": "silent",
+    "args": [
+        "-p",
+        ".",
+        "-w"
+    ],
     "problemMatcher": "$tsc",
-    "isWatching": true
+    "isWatching": true,
+    "tasks": [
+        {
+            "label": "tsc",
+            "type": "shell",
+            "command": "tsc",
+            "args": [
+                "-p",
+                ".",
+                "-w"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Map generated Quick form types to the relevant Quickforms collections on the forms embedding them.

Only generate the relevant parts of the quick form types (they are not full forms).

This fixes #12 