### PR TITLE
Fix: Skip view fetching when viewNs is not configured

### DIFF
--- a/src/XrmDefinitelyTyped/Generation/DataRetrieval.fs
+++ b/src/XrmDefinitelyTyped/Generation/DataRetrieval.fs
@@ -116,7 +116,7 @@ let retrieveCrmVersion mainProxy =
   version
 
 /// Retrieve all the necessary CRM data
-let retrieveCrmData crmVersion entities solutions (mainProxy:IOrganizationService) skipInactiveForms =
+let retrieveCrmData crmVersion entities solutions (mainProxy:IOrganizationService) skipInactiveForms fetchViews =
   let nameMap = 
     retrieveEntityNameMap mainProxy
 
@@ -125,7 +125,7 @@ let retrieveCrmData crmVersion entities solutions (mainProxy:IOrganizationServic
     |> Array.sortBy(fun md -> md.LogicalName)
     
   let rawViewData, additionalEntityMetadata = 
-    match crmVersion .>= (8,2,0,0) with
+    match fetchViews && crmVersion .>= (8,2,0,0) with
     | false -> [||], [||]
     | true  -> retrieveViews entities originalRawEntityMetadata mainProxy
 

--- a/src/XrmDefinitelyTyped/Generation/GenerationMain.fs
+++ b/src/XrmDefinitelyTyped/Generation/GenerationMain.fs
@@ -10,7 +10,7 @@ open FileGeneration
 
 
 /// Retrieve data from CRM and setup raw state
-let retrieveRawState xrmAuth rSettings =
+let retrieveRawState xrmAuth rSettings fetchViews =
   let mainProxy = connectToCrm xrmAuth
 
   let crmVersion = retrieveCrmVersion mainProxy
@@ -19,7 +19,7 @@ let retrieveRawState xrmAuth rSettings =
   let skipInactiveForms = rSettings.skipInactiveForms
       
   // Retrieve data from CRM
-  retrieveCrmData crmVersion entities rSettings.solutions mainProxy skipInactiveForms
+  retrieveCrmData crmVersion entities rSettings.solutions mainProxy skipInactiveForms fetchViews
 
 /// Main generator function
 let generateFromRaw gSettings rawState =

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
@@ -53,7 +53,7 @@ type XrmDefinitelyTyped private () =
     try
     #endif 
       
-      retrieveRawState xrmAuth rSettings
+      retrieveRawState xrmAuth rSettings (gSettings.viewNs |> Option.isSome)
       |> generateFromRaw gSettings
       printfn "\nSuccessfully generated all TypeScript declaration files."
 
@@ -76,7 +76,7 @@ type XrmDefinitelyTyped private () =
       let serializer = DataContractJsonSerializer(typeof<RawState>, null, System.Int32.MaxValue, true, null, false)
       use stream = new FileStream(filePath, FileMode.Create)
 
-      retrieveRawState xrmAuth rSettings
+      retrieveRawState xrmAuth rSettings true
       |> fun state -> serializer.WriteObject(stream, state)
       printfn "\nSuccessfully saved retrieved data to file %s." (Path.GetFullPath filePath)
 


### PR DESCRIPTION
Views are only fetched when viewNs is set in gSettings, avoiding the "index out of range" crash during view processing reported in #266 and #124. SaveMetadataToFile continues to fetch views unconditionally.