### PR TITLE
Port to .NET 8 and Dataverse ServiceClient

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ generating early-bound .NET classes for server-side code, it generates TypeScrip
 
 ### Build
 
-Recommended environment: [Visual Studio 2019](https://www.visualstudio.com/downloads/)
-
 **Requirements:**
 
-* [F# 4.0+](https://www.microsoft.com/en-us/download/details.aspx?id=48179)
+* [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 * [Node.js and npm](https://nodejs.org/)
 * [TypeScript 2.0+](http://www.typescriptlang.org/index.html#download-links)
 
@@ -33,9 +31,11 @@ Recommended environment: [Visual Studio 2019](https://www.visualstudio.com/downl
 This project is created from [ProjectScaffold](http://fsprojects.github.io/ProjectScaffold/index.html), 
 which uses [FAKE](http://fsharp.github.io/FAKE/) to automate a lot of the build tasks (setup, build, test, docs, nuget package, releases, etc).
 
-Before you can build/run the project from Visual Studio, you need to run `build` from the command-line in the root folder. 
-This will trigger the default FAKE build. FAKE handles setting up the project and it's dependencies as needed, before running the actual MSBuild task on the project. 
-Once it has been set up correctly by FAKE, you will be able to build the project using Visual Studio from then on.
+Run `build` from the command line in the root folder to execute the FAKE build, or build the project directly:
+
+```bash
+dotnet build src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj -c Release
+```
 
 
 ### Test

--- a/build.fsx
+++ b/build.fsx
@@ -136,8 +136,8 @@ Target.create "Build" (fun _ ->
 
 Target.create "RunXDT" (fun _ ->
   // Run XrmDefinitelyTyped
-  let pathToRelease = Path.GetFullPath @"src/XrmDefinitelyTyped/bin/Release/net462"
-  let result = 
+  let pathToRelease = Path.GetFullPath @"src/XrmDefinitelyTyped/bin/Release/net8.0"
+  let arguments =
     [
       "load", "../../../XdtData.json"
       "out", "../../../../../test/typings/XRM"
@@ -147,12 +147,16 @@ Target.create "RunXDT" (fun _ ->
       "entities", "account,contact"
     ]
     |> List.map (fun (k,v) -> sprintf "-%s:%s" k v)
-    |> CreateProcess.fromRawCommand (pathToRelease ++ @"XrmDefinitelyTyped.exe")
+    |> fun arguments -> (pathToRelease ++ @"XrmDefinitelyTyped.dll") :: arguments
+
+  let result =
+    arguments
+    |> CreateProcess.fromRawCommand "dotnet"
     |> CreateProcess.withWorkingDirectory pathToRelease
     |> Proc.run
 
-  if result.ExitCode <> 0 then 
-    failwithf "XrmDefinitelyTyped.exe returned with a non-zero exit code"
+  if result.ExitCode <> 0 then
+    failwithf "XrmDefinitelyTyped returned with a non-zero exit code"
 )
 
 Target.create "Test" (fun _ ->

--- a/docs/content/tool-usage.fsx
+++ b/docs/content/tool-usage.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 #r "../../bin/XrmDefinitelyTyped/Microsoft.Xrm.Sdk.dll"
-#r "../../bin/XrmDefinitelyTyped/XrmDefinitelyTyped.exe"
+#r "../../bin/XrmDefinitelyTyped/XrmDefinitelyTyped.dll"
 
 (**
 Usage of XrmDefinitelyTyped 
@@ -20,7 +20,8 @@ Here is the full list of arguments for configuring the tool:
 
 | Argument          | Short-hand  | Description   
 | :-                | :-          |:-             
-| url               |             | URL to the Organization.svc
+| url               |             | Dataverse environment URL.
+| method            |             | Connection method: OAuth, ClientSecret, ConnectionString, or legacy Proxy (unsupported on modern .NET).
 | username          | u, usr      | Username for the CRM system.
 | password          | p, pwd      | Password for the CRM system.
 | domain            | d, dmn      | Domain for the user.
@@ -68,8 +69,9 @@ The arguments are similar to those given to the [CrmSvcUtil][crmsvcutil] tool.
 Example usage from a command prompt:
 
     [lang=bash]
-    XrmDefinitelyTyped.exe /url:http://<serverName>/<organizationName>/XRMServices/2011/Organization.svc  
-            /out:WebResources\typings\XRM /username:<username> /password:<password> /domain:<domainName>
+    XrmDefinitelyTyped.exe /url:https://<environment>.crm.dynamics.com /method:OAuth
+            /mfaAppId:<application-id> /mfaReturnUrl:http://localhost
+            /out:WebResources\typings\XRM /username:<username> /password:<password>
 
   [crmsvcutil]: https://msdn.microsoft.com/en-us/library/gg327844.aspx
 
@@ -85,8 +87,12 @@ open Microsoft.Xrm.Sdk.Client
 open DG.XrmDefinitelyTyped
 
 XrmDefinitelyTyped.GenerateFromCrm(
-  "http://<serverName>/<organizationName>/XRMServices/2011/Organization.svc", 
-  "username", "password", 
+  "https://<environment>.crm.dynamics.com",
+  method = ConnectionType.OAuth,
+  username = "username",
+  password = "password",
+  clientId = "application-id",
+  returnUrl = "http://localhost",
   outDir = @"WebResources\typings\XRM")
 
 

--- a/files/Run.fsx
+++ b/files/Run.fsx
@@ -1,13 +1,12 @@
 open System.Diagnostics
+open System.IO
 
-let shellExecute program args =
-  let startInfo = new ProcessStartInfo()
-  startInfo.FileName <- program
-  startInfo.Arguments <- args
-  startInfo.UseShellExecute <- true
+let assemblyPath = Path.Combine(__SOURCE_DIRECTORY__, "XrmDefinitelyTyped.dll")
+let startInfo = ProcessStartInfo("dotnet")
+startInfo.ArgumentList.Add(assemblyPath)
+startInfo.UseShellExecute <- false
 
-  let proc = Process.Start(startInfo)
-  proc.WaitForExit()
-  ()
-
-shellExecute (__SOURCE_DIRECTORY__ + "/XrmDefinitelyTyped.exe") ""
+use proc = Process.Start(startInfo)
+proc.WaitForExit()
+if proc.ExitCode <> 0 then
+  failwithf "XrmDefinitelyTyped returned exit code %d" proc.ExitCode

--- a/files/Run.ps1
+++ b/files/Run.ps1
@@ -1,2 +1,6 @@
-Push-Location (split-path $SCRIPT:MyInvocation.MyCommand.Path -parent)
-.\XrmDefinitelyTyped.exe
+Push-Location (Split-Path $SCRIPT:MyInvocation.MyCommand.Path -Parent)
+try {
+  dotnet .\XrmDefinitelyTyped.dll
+} finally {
+  Pop-Location
+}

--- a/files/XrmDefinitelyTyped.exe.config
+++ b/files/XrmDefinitelyTyped.exe.config
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="url" value="https://INSTANCE.crm4.dynamics.com/XRMServices/2011/Organization.svc" />
+    <add key="url" value="https://INSTANCE.crm4.dynamics.com" />
+    <add key="method" value="OAuth" />
     <add key="username" value="admin@INSTANCE.onmicrosoft.com" />
     <add key="password" value="pass@word1" />
     <add key="out" value="../typings/XRM" />
@@ -9,7 +10,7 @@
     <add key="entities" value="account, contact" />
     <add key="web" value="" />
     <add key="jsLib" value="../src/lib" />
-    <add key="mfaAppId" value="" />
-    <add key="mfaReturnUrl" value=""/>
+    <add key="mfaAppId" value="APPLICATION-ID" />
+    <add key="mfaReturnUrl" value="http://localhost"/>
   </appSettings>
 </configuration>

--- a/src/XrmDefinitelyTyped/App.config
+++ b/src/XrmDefinitelyTyped/App.config
@@ -8,7 +8,4 @@
     <add key="web" value="WebNs" />
     <add key="entities" value="account,contact,activitymimeattachment" />
   </appSettings>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-  </startup>
 </configuration>

--- a/src/XrmDefinitelyTyped/CommandLine/Arguments.fs
+++ b/src/XrmDefinitelyTyped/CommandLine/Arguments.fs
@@ -105,7 +105,7 @@ type Args private () =
   static member connectionArgs = [
     { command="url"
       altCommands=[]
-      description="Url to the Organization.svc"
+      description="Dataverse environment URL"
       required=true }
     
     { command="method"
@@ -231,20 +231,24 @@ type Args private () =
 
   // Usage
   static member usageString = 
-    @"Usage: XrmDefinitelyTyped.exe /url:http://<serverName>/<organizationName>/XRMServices/2011/Organization.svc /u:<username> /p:<password>"
+    @"Usage: XrmDefinitelyTyped.exe /url:https://<environment>.crm.dynamics.com /method:OAuth /mfaAppId:<application-id> /mfaReturnUrl:<redirect-uri> /u:<username> /p:<password>"
   
   static member helpArgs = [ "?"; "help"; "-h"; "-help"; "--help"; "/h"; "/help" ] |> Set.ofList
 
   static member configFileMissing () =
-    File.Exists(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile) |> not
+    let config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None)
+    File.Exists(config.FilePath) |> not
 
   static member genConfig () =
     let configmanager = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None)
     let config = configmanager.AppSettings.Settings
     config.AllKeys |> Array.iter config.Remove
-    config.Add("url", "https://INSTANCE.crm4.dynamics.com/XRMServices/2011/Organization.svc")
+    config.Add("url", "https://INSTANCE.crm4.dynamics.com")
+    config.Add("method", "OAuth")
     config.Add("username","admin@INSTANCE.onmicrosoft.com")
     config.Add("password", "pass@word1")
+    config.Add("mfaAppId", "APPLICATION-ID")
+    config.Add("mfaReturnUrl", "http://localhost")
     config.Add("out", "../typings/XRM")
     config.Add("solutions", "")
     config.Add("entities", "account, contact")

--- a/src/XrmDefinitelyTyped/CommandLine/Program.fs
+++ b/src/XrmDefinitelyTyped/CommandLine/Program.fs
@@ -10,8 +10,8 @@ open CommandLineHelper
 
 let getXrmAuth parsedArgs = 
   let ap = 
-    getArg parsedArgs "ap" (fun ap ->
-      Enum.Parse(typeof<AuthenticationProviderType>, ap) 
+    getArg parsedArgs "ap" (fun (ap: string) ->
+      Enum.Parse(typeof<AuthenticationProviderType>, ap)
         :?> AuthenticationProviderType)
   let method =
     getArg parsedArgs "method" (fun method ->

--- a/src/XrmDefinitelyTyped/Crm/CrmAuth.fs
+++ b/src/XrmDefinitelyTyped/Crm/CrmAuth.fs
@@ -1,82 +1,52 @@
-﻿module DG.XrmDefinitelyTyped.CrmAuth
+module DG.XrmDefinitelyTyped.CrmAuth
 
 open System
-open System.Net
-open Microsoft.IdentityModel.Clients.ActiveDirectory
-open Microsoft.Xrm.Sdk
-open Microsoft.Xrm.Sdk.Client
-open Microsoft.Xrm.Tooling.Connector
-open Microsoft.Xrm.Sdk.WebServiceClient
 open System.IO
+open System.Security
+open Microsoft.Xrm.Sdk
+open Microsoft.PowerPlatform.Dataverse.Client
+open Microsoft.PowerPlatform.Dataverse.Client.Auth
 
-// Get credentials based on provider, username, password and domain
-let internal getCredentials provider username password domain =
-
-  let (password_:string) = password
-  let ac = AuthenticationCredentials()
-
-  match provider with
-  | AuthenticationProviderType.ActiveDirectory ->
-      ac.ClientCredentials.Windows.ClientCredential <-
-        new NetworkCredential(username, password_, domain)
-
-  | AuthenticationProviderType.OnlineFederation -> // CRM Online using Office 365 
-      ac.ClientCredentials.UserName.UserName <- username
-      ac.ClientCredentials.UserName.Password <- password_
-
-  | AuthenticationProviderType.Federation -> // Local Federation
-      ac.ClientCredentials.UserName.UserName <- username
-      ac.ClientCredentials.UserName.Password <- password_
-
-  | _ -> failwith "No valid authentification provider was used."
-
-  ac
-
-// Get Organization Service Proxy
-let internal getOrganizationServiceProxy
-  (serviceManagement:IServiceManagement<IOrganizationService>)
-  (authCredentials:AuthenticationCredentials) =
-  let ac = authCredentials
-
-  match serviceManagement.AuthenticationType with
-  | AuthenticationProviderType.ActiveDirectory ->
-      new OrganizationServiceProxy(serviceManagement, ac.ClientCredentials) :> IOrganizationService
-  | _ ->
-      new OrganizationServiceProxy(serviceManagement, ac.SecurityTokenResponse) :> IOrganizationService
-
-// Get Organization Service Proxy using MFA
-let ensureClientIsReady (client: CrmServiceClient) =
+let ensureClientIsReady (client: ServiceClient) =
   match client.IsReady with
   | false ->
-    let s = sprintf "Client could not authenticate. If the application user was just created, it might take a while before it is available.\n%s" client.LastCrmError 
+    let s = sprintf "Client could not authenticate. If the application user was just created, it might take a while before it is available.\n%s" client.LastError
     in failwith s
   | true -> client
 
-let internal getCrmServiceClient userName password (orgUrl:Uri) mfaAppId mfaReturnUrl =
-  let mutable orgName = ""
-  let mutable region = ""
-  let mutable isOnPrem = false
-  Utilities.GetOrgnameAndOnlineRegionFromServiceUri(orgUrl, &region, &orgName, &isOnPrem)
-  let cacheFileLocation = System.IO.Path.Combine(System.IO.Path.GetTempPath(), orgName, "oauth-cache.txt")
-  new CrmServiceClient(userName, CrmServiceClient.MakeSecureString(password), region, orgName, false, null, null, mfaAppId, Uri(mfaReturnUrl), cacheFileLocation, null)
+let private makeSecureString (value: string) =
+  let secureValue = new SecureString()
+  value |> Seq.iter secureValue.AppendChar
+  secureValue.MakeReadOnly()
+  secureValue
+
+// OAuth user authentication (with MFA support) through the Dataverse ServiceClient
+let internal getCrmServiceClient username password (orgUrl:Uri) mfaAppId mfaReturnUrl =
+  if String.IsNullOrWhiteSpace mfaAppId then failwith "OAuth authentication requires mfaAppId"
+  if String.IsNullOrWhiteSpace mfaReturnUrl then failwith "OAuth authentication requires mfaReturnUrl"
+  let cacheFileLocation = Path.Combine(Path.GetTempPath(), orgUrl.Host, "oauth-cache.txt")
+  let securePassword = makeSecureString password
+  new ServiceClient(
+    username,
+    securePassword,
+    orgUrl,
+    true,
+    mfaAppId,
+    Uri(mfaReturnUrl),
+    PromptBehavior.Auto,
+    false,
+    cacheFileLocation,
+    null)
   |> ensureClientIsReady
   |> fun x -> x :> IOrganizationService
 
-let internal getCrmServiceClientClientSecret (org: Uri) appId clientSecret =
-  new CrmServiceClient(org, appId, CrmServiceClient.MakeSecureString(clientSecret), true, Path.Combine(Path.GetTempPath(), appId, "oauth-cache.txt"))
+let internal getCrmServiceClientClientSecret (org: Uri) (appId: string) (clientSecret: string) =
+  new ServiceClient(org, appId, clientSecret, true)
   |> ensureClientIsReady
   |> fun x -> x :> IOrganizationService
 
 let internal getCrmServiceClientConnectionString (connectionString: string option) =
   if connectionString.IsNone then failwith "Ensure connectionString is set when using ConnectionString method" else
-  new CrmServiceClient(connectionString.Value)
+  new ServiceClient(connectionString.Value)
   |> ensureClientIsReady
   |> fun x -> x :> IOrganizationService
-
-// Authentication
-let internal getServiceManagement org = 
-    ServiceConfigurationFactory.CreateManagement<IOrganizationService>(org)
-
-let internal authenticate (serviceManagement:IServiceManagement<IOrganizationService>) ap username password domain =
-    serviceManagement.Authenticate(getCredentials ap username password domain)
-  

--- a/src/XrmDefinitelyTyped/Crm/CrmBaseHelper.fs
+++ b/src/XrmDefinitelyTyped/Crm/CrmBaseHelper.fs
@@ -5,18 +5,14 @@ open System.Threading.Tasks
 
 open Utility
 open Microsoft.Xrm.Sdk
-open Microsoft.Xrm.Sdk.Client
 open Microsoft.Xrm.Sdk.Messages
 open Microsoft.Xrm.Sdk.Query
 open Microsoft.Xrm.Sdk.Metadata
 open Microsoft.Crm.Sdk.Messages
-open Microsoft.Xrm.Sdk.WebServiceClient
+open Microsoft.PowerPlatform.Dataverse.Client
 
 // Execute request
 let getResponse<'T when 'T :> OrganizationResponse> (proxy:IOrganizationService) request =
-  if(proxy :? OrganizationServiceProxy) then 
-    let orgProxy = proxy :?> OrganizationServiceProxy
-    orgProxy.Timeout <- TimeSpan(1,0,0)
   (proxy.Execute(request)) :?> 'T
 
 // Retrieve version
@@ -213,22 +209,18 @@ let retrieveSolutionEntities (proxy:IOrganizationService) solutionName =
 
 // Proxy helper that makes it easy to get a new proxy instance
 let proxyHelper xrmAuth () =
-  let method = xrmAuth.method ?| ConnectionType.Proxy
+  let method = xrmAuth.method ?| ConnectionType.OAuth
   let username = xrmAuth.username ?| ""
   let password = xrmAuth.password ?| ""
-  let ap = xrmAuth.ap ?| AuthenticationProviderType.OnlineFederation
-  let domain = xrmAuth.domain ?| ""
   let clientId = xrmAuth.clientId ?| ""
   let returnUrl = xrmAuth.returnUrl ?| ""
   let clientSecret = xrmAuth.clientSecret ?| ""
 
-  let proxyInstance = 
+  let proxyInstance =
     match method with
     | Proxy ->
-      let manager = CrmAuth.getServiceManagement xrmAuth.url
-      let authToken = CrmAuth.authenticate manager ap username password domain
-      CrmAuth.getOrganizationServiceProxy manager authToken
-    | OAuth -> CrmAuth.getCrmServiceClient username password xrmAuth.url clientId returnUrl 
+      failwith "The 'Proxy' (WS-Trust/on-premises) connection method is not supported on modern .NET. Use method=OAuth, ClientSecret or ConnectionString instead."
+    | OAuth -> CrmAuth.getCrmServiceClient username password xrmAuth.url clientId returnUrl
     | ClientSecret -> CrmAuth.getCrmServiceClientClientSecret xrmAuth.url clientId clientSecret
     | ConnectionString -> CrmAuth.getCrmServiceClientConnectionString xrmAuth.connectionString
   proxyInstance

--- a/src/XrmDefinitelyTyped/Utility.fs
+++ b/src/XrmDefinitelyTyped/Utility.fs
@@ -23,7 +23,7 @@ let stringToOption s =
   | true  -> None
   | false -> Some s
 
-let parseInt str =
+let parseInt (str: string) =
   let mutable intvalue = 0
   if System.Int32.TryParse(str, &intvalue) then Some(intvalue)
   else None
@@ -38,7 +38,7 @@ let rec getFirstExceptionMessage (ex:Exception) =
   | _ -> ex.Message
 
 let (|StartsWithNumber|) (str:string) = str.Length > 0 && str.[0] >= '0' && str.[0] <= '9'
-let (|StartsWith|_|) needle (haystack : string) = if haystack.StartsWith(needle) then Some() else None
+let (|StartsWith|_|) (needle: string) (haystack : string) = if haystack.StartsWith(needle) then Some() else None
 
   
 let keywords = [ "import"; "export"; "class"; "enum"; "var"; "for"; "if"; "else"; "const"; "true"; "false" ] |> Set.ofList

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fs
@@ -73,7 +73,12 @@ type XrmDefinitelyTyped private () =
         ?>>? (String.IsNullOrWhiteSpace >> not)
         ?| "XdtData.json"
 
-      let serializer = DataContractJsonSerializer(typeof<RawState>, null, System.Int32.MaxValue, true, null, false)
+      let serializerSettings =
+        DataContractJsonSerializerSettings(
+          MaxItemsInObjectGraph = System.Int32.MaxValue,
+          IgnoreExtensionDataObject = true,
+          EmitTypeInformation = System.Runtime.Serialization.EmitTypeInformation.Never)
+      let serializer = DataContractJsonSerializer(typeof<RawState>, serializerSettings)
       use stream = new FileStream(filePath, FileMode.Create)
 
       retrieveRawState xrmAuth rSettings

--- a/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
+++ b/src/XrmDefinitelyTyped/XrmDefinitelyTyped.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
@@ -105,35 +105,17 @@
     <None Include="EnvInfo.config" />
     <Content Include="bin\Release\$(TargetFramework)\*.dll" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
     <Content Include="bin\Release\$(TargetFramework)\*.exe" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
+    <Content Include="bin\Release\$(TargetFramework)\*.json" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
     <Content Include="bin\Release\$(TargetFramework)\XrmDefinitelyTyped.xml" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
     <Content Include="..\..\files\*" Pack="true" PackagePath="content\XrmDefinitelyTyped;contentFiles\any\any\XrmDefinitelyTyped" />
     <None Include="package.json" />
     <None Include="tsconfig.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.0.51" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.26" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.DirectoryServices" />
-    <Reference Include="System.DirectoryServices.AccountManagement" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.ServiceModel.Web" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-  <Target Name="RunGulp" BeforeTargets="BeforeBuild">
+  <Target Name="RunGulp" BeforeTargets="BeforeBuild" Condition="'$(SkipGulp)' != 'true'">
     <Exec Command="npm install" />
     <Exec Command="npm start" />
   </Target>


### PR DESCRIPTION
## Summary

- target .NET 8 and replace the legacy WS-Trust/ADAL XrmTooling authentication stack with `Microsoft.PowerPlatform.Dataverse.Client`
- support OAuth, client-secret, and connection-string flows; fail clearly for the unsupported legacy Proxy flow
- update CLI configuration, documentation, FAKE execution, and NuGet runtime packaging for the modern build
- replace Framework-only APIs and resolve F# overload ambiguities on the newer BCL

## Validation

- clean `dotnet restore` and Release build
- CLI `/help` smoke test
- offline generation from the checked-in `XdtData.json` fixture
- 98 TypeScript tests passing
- successful `dotnet pack`
- candidate-only Gitleaks scan: no findings
